### PR TITLE
Add luajit-bundled feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ jobs:
       - run:
           name: Run all tests / LuaJIT
           command: cargo test --all --no-default-features --features luajit
+      - run:
+          name: Run all tests / LuaJIT Bundled
+          command: cargo test --all --no-default-features --features luajit-bundled
       - save_cache:
           paths:
             - /usr/local/cargo/registry

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,12 @@ lua53 = []
 lua52 = []
 lua51 = []
 luajit = []
+luajit-bundled = ["luajit", "luajit2-sys"]
 
 [dependencies]
 num-traits = { version = "0.2.6" }
 bstr = { version = "0.2", features = ["std"], default_features = false }
+luajit2-sys = { version = "0.0.2", optional = true }
 
 [build-dependencies]
 cc = { version = "1.0" }

--- a/build.rs
+++ b/build.rs
@@ -175,7 +175,7 @@ fn main() {
         };
     }
 
-    #[cfg(feature = "luajit")]
+    #[cfg(all(feature = "luajit", not(feature = "luajit2-sys")))]
     {
         let lua = pkg_config::Config::new()
             .range_version((Bound::Included("2.0.5"), Bound::Unbounded))
@@ -185,5 +185,17 @@ fn main() {
             Ok(lua) => build_glue(&lua.include_paths),
             Err(err) => panic!(err),
         };
+    }
+
+    #[cfg(all(feature = "luajit", feature = "luajit2-sys"))]
+    {
+        let include_dir = std::env::var("DEP_LUAJIT_INCLUDE")
+            .expect("DEP_LUAJIT_INCLUDE not set by luajit2-sys");
+
+        let lib_name = std::env::var("DEP_LUAJIT_LIB_NAME")
+            .expect("DEP_LUAJIT_LIB_NAME not set by luajit2-sys");
+
+        build_glue(&[PathBuf::from(include_dir)]);
+        println!("cargo:rustc-link-lib=static={}", lib_name);
     }
 }


### PR DESCRIPTION
LuaJIT can now be enabled without being installed as a system package and now works in Windows.