### PR TITLE
Compile glue.c for HOST instead of TARGET.

### DIFF
--- a/build/main.rs
+++ b/build/main.rs
@@ -72,6 +72,7 @@ fn build_glue<P: AsRef<Path> + std::fmt::Debug>(include_path: &P) {
 
     let mut config = cc::Build::new();
     config.include(include_path);
+    config.target(&env::var("HOST").unwrap());
 
     // Compile and run glue.c
     let glue = build_dir.join("glue");


### PR DESCRIPTION
The glue binary is run on the host. `cc::Build` compiles for the target
by default. This is a problem when cross-compiling.