### PR TITLE
add the underlying cause of CallbackErrors to the display

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -211,8 +211,8 @@ impl fmt::Display for Error {
             Error::MismatchedRegistryKey => {
                 write!(fmt, "RegistryKey used from different Lua state")
             }
-            Error::CallbackError { ref traceback, .. } => {
-                write!(fmt, "callback error: {}", traceback)
+            Error::CallbackError { ref traceback, ref cause } => {
+                write!(fmt, "callback error: {}\n{}", cause, traceback)
             }
             Error::ExternalError(ref err) => write!(fmt, "{}", err),
         }


### PR DESCRIPTION
I had a hard time debugging an issue today because all I could see was the Lua traceback of a `CallbackError`, and not the source of the error. I had to guess where in my Rust library the error was happening so I could print the `cause` field. It would have been easier to find the issue if the `cause` field was printed in the first place, so here's a change that will hopefully save other people some trouble in the future.