### PR TITLE
Add stringified backtrace to WrappedError passed back to Lua

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -93,6 +93,14 @@ impl<'a> Debug<'a> {
             }
         }
     }
+
+    pub(crate) unsafe fn wrap(state: *mut ffi::lua_State, ar: *mut ffi::lua_Debug) -> Debug<'a> {
+        Debug {
+            ar: ar,
+            state: state,
+            _phantom: PhantomData,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -1507,7 +1507,7 @@ impl Lua {
                 // We must prevent interaction with userdata types other than UserData OR a WrappedError.
                 // WrappedPanics are automatically resumed.
                 if let Some(err) = get_wrapped_error(state, -1).as_ref() {
-                    let err = err.clone();
+                    let err = err.0.clone();
                     ffi::lua_pop(state, 1);
                     Value::Error(err)
                 } else if let Some(panic) = get_gc_userdata::<WrappedPanic>(state, -1).as_mut() {


### PR DESCRIPTION
This makes the behaviour consistent with how Lua behaves when a
normal string is used as error instead of a userdata.

When a string is used, the Lua runtime will add a complete
stacktrace to the error output; when a userdata is used, it will
not do that, but only display the tostring(ud) at the time the
error is printed.

This makes debugging things much harder (especially when writing
modules), because errors emitted by the Rust code (such as type
conversion errors) are not attribute to a code line.

However, this implementation has two important caveats:

- The runtime complexity of walking the stack and transforming it
  into a nice human-readable string; this complexity is to be
  expected to also exist in case of Lua doing that internally,
  modulo extra cost for utf8 checks inside Rust.

- When the WrappedError is transported back into and out of Rust,
  the stacktrace is lost and regenerated when passed back into
  Lua.

  This means that the error cause can be "shadowed" by passing
  through Rust.

  Handling this would require a more invasive change which allows
  chaining Error instances in a way which allows carrying the
  backtrace without changing the Error enum to contain an optional
  stacktrace in each variant; I’ll leave this to future work.

Fixes #44.