### PR TITLE
().to_lua(lua) -> Value::Nil

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -31,6 +31,12 @@ impl<'lua> FromLua<'lua> for Value<'lua> {
     }
 }
 
+impl<'lua> ToLua<'lua> for () {
+    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        Ok(Value::Nil)
+    }
+}
+
 impl<'lua> ToLua<'lua> for String<'lua> {
     fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
         Ok(Value::String(self))


### PR DESCRIPTION
_Disclaimer: I didn't make a local checkout / set up the local devenv to test this because it seems trivial? I'll be depending on CI to tell me if I'm wrong_

I find myself writing model functions implementing fallible mutations with no meaningful result that usually return `Result<(), Error>`. When exposing them to Lua, I then need to `.map(|_| mlua::Value::Nil)`. This is un-great because if the model function adds a meaningful result at some point, then it will be silently swallowed unless this is removed, and keeping it causes no compile-time problems. All this (both the boilerplate and the opportunity for human error) can be eliminated by implementing `ToLua<'lua> for ()`.