### PR TITLE
WIP: Add Lua::with_debug_iter for arbitrary access of stack info

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -14,8 +14,11 @@ use crate::util::callback_error;
 /// Lua code executing at the time that the hook function was called. Further information can be
 /// found in the [Lua 5.3 documentation][lua_doc].
 ///
+/// The `Debug` structure can also be accessed arbitrarily with [`Lua::with_debug_iter`].
+///
 /// [lua_doc]: https://www.lua.org/manual/5.3/manual.html#lua_Debug
 /// [`Lua::set_hook`]: crate::Lua::set_hook
+/// [`Lua::with_debug_iter`]: crate::Lua::with_debug_iter
 #[derive(Clone)]
 pub struct Debug<'a> {
     ar: *mut lua_Debug,
@@ -24,6 +27,14 @@ pub struct Debug<'a> {
 }
 
 impl<'a> Debug<'a> {
+    pub(crate) unsafe fn new(ar: &'a mut lua_Debug, state: *mut lua_State) -> Self {
+        Debug {
+            ar,
+            state,
+            _phantom: PhantomData,
+        }
+    }
+
     /// Returns the specific event that triggered the hook.
     ///
     /// For [Lua 5.1] `DebugEvent::TailCall` is used for return events to indicate a return

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub use crate::{ffi::lua_CFunction, ffi::lua_State};
 pub use crate::error::{Error, ExternalError, ExternalResult, Result};
 pub use crate::function::Function;
 pub use crate::hook::{Debug, DebugEvent, DebugNames, DebugSource, DebugStack, HookTriggers};
-pub use crate::lua::{AsChunk, Chunk, ChunkMode, GCMode, Lua, LuaOptions};
+pub use crate::lua::{AsChunk, Chunk, ChunkMode, DebugIter, GCMode, Lua, LuaOptions};
 pub use crate::multi::Variadic;
 pub use crate::scope::Scope;
 pub use crate::stdlib::StdLib;


### PR DESCRIPTION
Hi! I had a need for `lua_getstack` while trying to implement a custom log function, and found that `mlua` didn't have a wrapper for it, so I decided to add one myself. It isn't playing very well with the existing `Debug` API, however, so I'm putting this up as a draft PR to see if what I'm doing makes sense, and if some breaking changes could be made to accommodate this use case better.

This adds `Lua::with_debug_iter` which takes a closure that takes a lending iterator of `Debug` instances as an argument. This is an unfortunate artifact of the current API design, with `Debug` borrowing, instead of owning the underlying `lua_Debug` C struct. It also sets a bogus `LUA_HOOKCALL` value to the `event` field, since the current signature of `Debug::event` only considered the case of hook argument.

The intended use case is exposing custom log functions to Lua code.

A more natural API could potentially be exposed if some breaking changes could be made to the `Debug` type to make it own or be generic over the `lua_Debug` struct.