### PR TITLE
glue: fix unused-value warning in try_write

### DIFF
--- a/src/ffi/glue/glue.c
+++ b/src/ffi/glue/glue.c
@@ -107,7 +107,7 @@ int try_write(char **str, char c, size_t n, size_t *written, size_t szstr) {
   if (szstr - *written < n) {
     return 0;
   }
-  for (; n; n--, *written++)
+  for (; n; n--, (*written)++)
     *(*str)++ = c;
   return 1;
 }


### PR DESCRIPTION
Previously, building with clang was bailing with:

```
  --- stderr
  src/ffi/glue/glue.c:110:18: warning: expression result unused [-Wunused-value]
    for (; n; n--, *written++)
                   ^~~~~~~~~~
```