### PR TITLE
support luajit version 2.0.4

### DIFF
--- a/build/find_normal.rs
+++ b/build/find_normal.rs
@@ -79,7 +79,7 @@ pub fn probe_lua() -> Option<PathBuf> {
     #[cfg(feature = "luajit")]
     {
         let lua = pkg_config::Config::new()
-            .range_version((Bound::Included("2.0.5"), Bound::Unbounded))
+            .range_version((Bound::Included("2.0.4"), Bound::Unbounded))
             .cargo_metadata(need_lua_lib)
             .probe("luajit");
 


### PR DESCRIPTION
CentOS 7 has luajit 2.0.4 available in epel repo. All tests `cargo test --tests --release --no-default-features --features "luajit async send"` passed with luajit 2.0.4.