### PR TITLE
Add parking_lot dependency and feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,7 @@ jobs:
       run: |
         cargo build --features "${{ matrix.lua }},vendored"
         cargo build --features "${{ matrix.lua }},vendored,async,send,serialize,macros"
+        cargo build --features "${{ matrix.lua }},vendored,async,serialize,macros,parking_lot"
       shell: bash
     - name: Build ${{ matrix.lua }} pkg-config
       if: ${{ matrix.os == 'ubuntu-20.04' && matrix.lua != 'lua54' }}
@@ -128,12 +129,14 @@ jobs:
       run: |
         cargo test --features "${{ matrix.lua }},vendored"
         cargo test --features "${{ matrix.lua }},vendored,async,send,serialize,macros"
+        cargo test --features "${{ matrix.lua }},vendored,async,serialize,macros,parking_lot"
       shell: bash
     - name: Run compile tests (macos lua54)
       if: ${{ matrix.os == 'macos-latest' && matrix.lua == 'lua54' }}
       run: |
         TRYBUILD=overwrite cargo test --features "${{ matrix.lua }},vendored" -- --ignored
         TRYBUILD=overwrite cargo test --features "${{ matrix.lua }},vendored,async,send,serialize,macros" -- --ignored
+        TRYBUILD=overwrite cargo test --features "${{ matrix.lua }},vendored,async,serialize,macros,parking_lot" -- --ignored
       shell: bash
 
   test_with_sanitizer:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ with async/await features and support of writing native Lua modules in Rust.
 """
 
 [package.metadata.docs.rs]
-features = ["lua54", "vendored", "async", "send", "serialize", "macros"]
+features = ["lua54", "vendored", "async", "send", "serialize", "macros", "parking_lot"]
 rustdoc-args = ["--cfg", "docsrs"]
 
 [workspace]
@@ -53,6 +53,7 @@ futures-task = { version = "0.3.5", optional = true }
 futures-util = { version = "0.3.5", optional = true }
 serde = { version = "1.0", optional = true }
 erased-serde = { version = "0.3", optional = true }
+parking_lot = { version = "0.12", optional = true }
 
 [build-dependencies]
 cc = { version = "1.0" }

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -1,4 +1,9 @@
-use std::sync::{Arc, Mutex, RwLock};
+use std::sync::Arc;
+#[cfg(not(feature = "parking_lot"))]
+use std::sync::{Mutex, RwLock};
+
+#[cfg(feature = "parking_lot")]
+use parking_lot::{Mutex, RwLock};
 
 #[cfg(not(feature = "send"))]
 use std::{cell::RefCell, rc::Rc};
@@ -623,7 +628,10 @@ fn test_userdata_wrapped() -> Result<()> {
     "#,
     )
     .exec()?;
+    #[cfg(not(feature = "parking_lot"))]
     assert_eq!(ud2.lock().unwrap().0, 3);
+    #[cfg(feature = "parking_lot")]
+    assert_eq!(ud2.lock().0, 3);
 
     let ud3 = Arc::new(RwLock::new(MyUserData(3)));
     globals.set("arc_rwlock_ud", ud3.clone())?;
@@ -634,7 +642,10 @@ fn test_userdata_wrapped() -> Result<()> {
     "#,
     )
     .exec()?;
+    #[cfg(not(feature = "parking_lot"))]
     assert_eq!(ud3.read().unwrap().0, 4);
+    #[cfg(feature = "parking_lot")]
+    assert_eq!(ud3.read().0, 4);
 
     // Test drop
     globals.set("arc_mutex_ud", Nil)?;


### PR DESCRIPTION
I have a project that I'm working on where I want to use [`parking_lot`](https://github.com/Amanieu/parking_lot)s `Mutex` due to its performance, and due to the foreign types trait restriction I have to implement it in this library. I'm not 100% sure how this would work if a user enables both the `send` and `parking_lot` feature due to this: `To allow sending MutexGuards and RwLock*Guards to other threads, enable the send_guard option.` 