### PR TITLE
Remove 'lua lifetimes

### DIFF
--- a/src/conversion.rs
+++ b/src/conversion.rs
@@ -20,30 +20,30 @@ use crate::types::{LightUserData, MaybeSend};
 use crate::userdata::{AnyUserData, UserData};
 use crate::value::{FromLua, Nil, ToLua, Value};
 
-impl<'lua> ToLua<'lua> for Value<'lua> {
+impl ToLua for Value {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(self)
     }
 }
 
-impl<'lua> FromLua<'lua> for Value<'lua> {
+impl FromLua for Value {
     #[inline]
-    fn from_lua(lua_value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+    fn from_lua(lua_value: Value, _: &Lua) -> Result<Self> {
         Ok(lua_value)
     }
 }
 
-impl<'lua> ToLua<'lua> for String<'lua> {
+impl ToLua for String {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(Value::String(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for String<'lua> {
+impl FromLua for String {
     #[inline]
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<String<'lua>> {
+    fn from_lua(value: Value, lua: &Lua) -> Result<String> {
         let ty = value.type_name();
         lua.coerce_string(value)?
             .ok_or_else(|| Error::FromLuaConversionError {
@@ -54,16 +54,16 @@ impl<'lua> FromLua<'lua> for String<'lua> {
     }
 }
 
-impl<'lua> ToLua<'lua> for Table<'lua> {
+impl ToLua for Table {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(Value::Table(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for Table<'lua> {
+impl FromLua for Table {
     #[inline]
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Table<'lua>> {
+    fn from_lua(value: Value, _: &Lua) -> Result<Table> {
         match value {
             Value::Table(table) => Ok(table),
             _ => Err(Error::FromLuaConversionError {
@@ -75,16 +75,16 @@ impl<'lua> FromLua<'lua> for Table<'lua> {
     }
 }
 
-impl<'lua> ToLua<'lua> for Function<'lua> {
+impl ToLua for Function {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(Value::Function(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for Function<'lua> {
+impl FromLua for Function {
     #[inline]
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Function<'lua>> {
+    fn from_lua(value: Value, _: &Lua) -> Result<Function> {
         match value {
             Value::Function(table) => Ok(table),
             _ => Err(Error::FromLuaConversionError {
@@ -96,16 +96,16 @@ impl<'lua> FromLua<'lua> for Function<'lua> {
     }
 }
 
-impl<'lua> ToLua<'lua> for Thread<'lua> {
+impl ToLua for Thread {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(Value::Thread(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for Thread<'lua> {
+impl FromLua for Thread {
     #[inline]
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Thread<'lua>> {
+    fn from_lua(value: Value, _: &Lua) -> Result<Thread> {
         match value {
             Value::Thread(t) => Ok(t),
             _ => Err(Error::FromLuaConversionError {
@@ -117,16 +117,16 @@ impl<'lua> FromLua<'lua> for Thread<'lua> {
     }
 }
 
-impl<'lua> ToLua<'lua> for AnyUserData<'lua> {
+impl ToLua for AnyUserData {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(Value::UserData(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for AnyUserData<'lua> {
+impl FromLua for AnyUserData {
     #[inline]
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<AnyUserData<'lua>> {
+    fn from_lua(value: Value, _: &Lua) -> Result<AnyUserData> {
         match value {
             Value::UserData(ud) => Ok(ud),
             _ => Err(Error::FromLuaConversionError {
@@ -138,16 +138,16 @@ impl<'lua> FromLua<'lua> for AnyUserData<'lua> {
     }
 }
 
-impl<'lua, T: 'static + MaybeSend + UserData> ToLua<'lua> for T {
+impl<'lua, T: 'static + MaybeSend + UserData> ToLua for T {
     #[inline]
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::UserData(lua.create_userdata(self)?))
     }
 }
 
-impl<'lua, T: 'static + UserData + Clone> FromLua<'lua> for T {
+impl<'lua, T: 'static + UserData + Clone> FromLua for T {
     #[inline]
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<T> {
+    fn from_lua(value: Value, _: &Lua) -> Result<T> {
         match value {
             Value::UserData(ud) => Ok(ud.borrow::<T>()?.clone()),
             _ => Err(Error::FromLuaConversionError {
@@ -159,16 +159,16 @@ impl<'lua, T: 'static + UserData + Clone> FromLua<'lua> for T {
     }
 }
 
-impl<'lua> ToLua<'lua> for Error {
+impl ToLua for Error {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(Value::Error(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for Error {
+impl FromLua for Error {
     #[inline]
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Error> {
+    fn from_lua(value: Value, lua: &Lua) -> Result<Error> {
         match value {
             Value::Error(err) => Ok(err),
             val => Ok(Error::RuntimeError(
@@ -180,16 +180,16 @@ impl<'lua> FromLua<'lua> for Error {
     }
 }
 
-impl<'lua> ToLua<'lua> for bool {
+impl ToLua for bool {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(Value::Boolean(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for bool {
+impl FromLua for bool {
     #[inline]
-    fn from_lua(v: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+    fn from_lua(v: Value, _: &Lua) -> Result<Self> {
         match v {
             Value::Nil => Ok(false),
             Value::Boolean(b) => Ok(b),
@@ -198,16 +198,16 @@ impl<'lua> FromLua<'lua> for bool {
     }
 }
 
-impl<'lua> ToLua<'lua> for LightUserData {
+impl ToLua for LightUserData {
     #[inline]
-    fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, _: &Lua) -> Result<Value> {
         Ok(Value::LightUserData(self))
     }
 }
 
-impl<'lua> FromLua<'lua> for LightUserData {
+impl FromLua for LightUserData {
     #[inline]
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+    fn from_lua(value: Value, _: &Lua) -> Result<Self> {
         match value {
             Value::LightUserData(ud) => Ok(ud),
             _ => Err(Error::FromLuaConversionError {
@@ -219,16 +219,16 @@ impl<'lua> FromLua<'lua> for LightUserData {
     }
 }
 
-impl<'lua> ToLua<'lua> for StdString {
+impl ToLua for StdString {
     #[inline]
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(&self)?))
     }
 }
 
-impl<'lua> FromLua<'lua> for StdString {
+impl FromLua for StdString {
     #[inline]
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
+    fn from_lua(value: Value, lua: &Lua) -> Result<Self> {
         let ty = value.type_name();
         Ok(lua
             .coerce_string(value)?
@@ -242,27 +242,27 @@ impl<'lua> FromLua<'lua> for StdString {
     }
 }
 
-impl<'lua> ToLua<'lua> for &str {
+impl ToLua for &str {
     #[inline]
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self)?))
     }
 }
 
-impl<'lua> ToLua<'lua> for Cow<'_, str> {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl ToLua for Cow<'_, str> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self.as_bytes())?))
     }
 }
 
-impl<'lua> ToLua<'lua> for Box<str> {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl ToLua for Box<str> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(&*self)?))
     }
 }
 
-impl<'lua> FromLua<'lua> for Box<str> {
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
+impl FromLua for Box<str> {
+    fn from_lua(value: Value, lua: &Lua) -> Result<Self> {
         let ty = value.type_name();
         Ok(lua
             .coerce_string(value)?
@@ -277,14 +277,14 @@ impl<'lua> FromLua<'lua> for Box<str> {
     }
 }
 
-impl<'lua> ToLua<'lua> for CString {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl ToLua for CString {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self.as_bytes())?))
     }
 }
 
-impl<'lua> FromLua<'lua> for CString {
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
+impl FromLua for CString {
+    fn from_lua(value: Value, lua: &Lua) -> Result<Self> {
         let ty = value.type_name();
         let string = lua
             .coerce_string(value)?
@@ -305,26 +305,26 @@ impl<'lua> FromLua<'lua> for CString {
     }
 }
 
-impl<'lua> ToLua<'lua> for &CStr {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl ToLua for &CStr {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self.to_bytes())?))
     }
 }
 
-impl<'lua> ToLua<'lua> for Cow<'_, CStr> {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl ToLua for Cow<'_, CStr> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(self.to_bytes())?))
     }
 }
 
-impl<'lua> ToLua<'lua> for BString {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl ToLua for BString {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(&self)?))
     }
 }
 
-impl<'lua> FromLua<'lua> for BString {
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
+impl FromLua for BString {
+    fn from_lua(value: Value, lua: &Lua) -> Result<Self> {
         let ty = value.type_name();
         Ok(BString::from(
             lua.coerce_string(value)?
@@ -339,16 +339,16 @@ impl<'lua> FromLua<'lua> for BString {
     }
 }
 
-impl<'lua> ToLua<'lua> for &BStr {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl ToLua for &BStr {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::String(lua.create_string(&self)?))
     }
 }
 
 macro_rules! lua_convert_int {
     ($x:ty) => {
-        impl<'lua> ToLua<'lua> for $x {
-            fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        impl ToLua for $x {
+            fn to_lua(self, _: &Lua) -> Result<Value> {
                 cast(self)
                     .map(Value::Integer)
                     .or_else(|| cast(self).map(Value::Number))
@@ -361,8 +361,8 @@ macro_rules! lua_convert_int {
             }
         }
 
-        impl<'lua> FromLua<'lua> for $x {
-            fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
+        impl FromLua for $x {
+            fn from_lua(value: Value, lua: &Lua) -> Result<Self> {
                 let ty = value.type_name();
                 (if let Value::Integer(i) = value {
                     cast(i)
@@ -404,8 +404,8 @@ lua_convert_int!(usize);
 
 macro_rules! lua_convert_float {
     ($x:ty) => {
-        impl<'lua> ToLua<'lua> for $x {
-            fn to_lua(self, _: &'lua Lua) -> Result<Value<'lua>> {
+        impl ToLua for $x {
+            fn to_lua(self, _: &Lua) -> Result<Value> {
                 cast(self)
                     .ok_or_else(|| Error::ToLuaConversionError {
                         from: stringify!($x),
@@ -416,8 +416,8 @@ macro_rules! lua_convert_float {
             }
         }
 
-        impl<'lua> FromLua<'lua> for $x {
-            fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
+        impl FromLua for $x {
+            fn from_lua(value: Value, lua: &Lua) -> Result<Self> {
                 let ty = value.type_name();
                 lua.coerce_number(value)?
                     .ok_or_else(|| Error::FromLuaConversionError {
@@ -440,31 +440,31 @@ macro_rules! lua_convert_float {
 lua_convert_float!(f32);
 lua_convert_float!(f64);
 
-impl<'lua, T> ToLua<'lua> for &[T]
+impl<'lua, T> ToLua for &[T]
 where
-    T: Clone + ToLua<'lua>,
+    T: Clone + ToLua,
 {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::Table(
             lua.create_sequence_from(self.iter().cloned())?,
         ))
     }
 }
 
-impl<'lua, T, const N: usize> ToLua<'lua> for [T; N]
+impl<'lua, T, const N: usize> ToLua for [T; N]
 where
-    T: ToLua<'lua>,
+    T: ToLua,
 {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::Table(lua.create_sequence_from(self)?))
     }
 }
 
-impl<'lua, T, const N: usize> FromLua<'lua> for [T; N]
+impl<'lua, T, const N: usize> FromLua for [T; N]
 where
-    T: FromLua<'lua>,
+    T: FromLua,
 {
-    fn from_lua(value: Value<'lua>, _lua: &'lua Lua) -> Result<Self> {
+    fn from_lua(value: Value, _lua: &Lua) -> Result<Self> {
         match value {
             #[cfg(feature = "luau")]
             Value::Vector(x, y, z) if N == 3 => Ok(mlua_expect!(
@@ -495,26 +495,26 @@ where
     }
 }
 
-impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Box<[T]> {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl<'lua, T: ToLua> ToLua for Box<[T]> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::Table(lua.create_sequence_from(self.into_vec())?))
     }
 }
 
-impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Box<[T]> {
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
+impl<'lua, T: FromLua> FromLua for Box<[T]> {
+    fn from_lua(value: Value, lua: &Lua) -> Result<Self> {
         Ok(Vec::<T>::from_lua(value, lua)?.into_boxed_slice())
     }
 }
 
-impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Vec<T> {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl<'lua, T: ToLua> ToLua for Vec<T> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::Table(lua.create_sequence_from(self)?))
     }
 }
 
-impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Vec<T> {
-    fn from_lua(value: Value<'lua>, _lua: &'lua Lua) -> Result<Self> {
+impl<'lua, T: FromLua> FromLua for Vec<T> {
+    fn from_lua(value: Value, _lua: &Lua) -> Result<Self> {
         match value {
             #[cfg(feature = "luau")]
             Value::Vector(x, y, z) => Ok(vec![
@@ -532,18 +532,18 @@ impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Vec<T> {
     }
 }
 
-impl<'lua, K: Eq + Hash + ToLua<'lua>, V: ToLua<'lua>, S: BuildHasher> ToLua<'lua>
+impl<'lua, K: Eq + Hash + ToLua, V: ToLua, S: BuildHasher> ToLua
     for HashMap<K, V, S>
 {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::Table(lua.create_table_from(self)?))
     }
 }
 
-impl<'lua, K: Eq + Hash + FromLua<'lua>, V: FromLua<'lua>, S: BuildHasher + Default> FromLua<'lua>
+impl<'lua, K: Eq + Hash + FromLua, V: FromLua, S: BuildHasher + Default> FromLua
     for HashMap<K, V, S>
 {
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+    fn from_lua(value: Value, _: &Lua) -> Result<Self> {
         if let Value::Table(table) = value {
             table.pairs().collect()
         } else {
@@ -556,14 +556,14 @@ impl<'lua, K: Eq + Hash + FromLua<'lua>, V: FromLua<'lua>, S: BuildHasher + Defa
     }
 }
 
-impl<'lua, K: Ord + ToLua<'lua>, V: ToLua<'lua>> ToLua<'lua> for BTreeMap<K, V> {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl<'lua, K: Ord + ToLua, V: ToLua> ToLua for BTreeMap<K, V> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::Table(lua.create_table_from(self)?))
     }
 }
 
-impl<'lua, K: Ord + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for BTreeMap<K, V> {
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+impl<'lua, K: Ord + FromLua, V: FromLua> FromLua for BTreeMap<K, V> {
+    fn from_lua(value: Value, _: &Lua) -> Result<Self> {
         if let Value::Table(table) = value {
             table.pairs().collect()
         } else {
@@ -576,20 +576,20 @@ impl<'lua, K: Ord + FromLua<'lua>, V: FromLua<'lua>> FromLua<'lua> for BTreeMap<
     }
 }
 
-impl<'lua, T: Eq + Hash + ToLua<'lua>, S: BuildHasher> ToLua<'lua> for HashSet<T, S> {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl<'lua, T: Eq + Hash + ToLua, S: BuildHasher> ToLua for HashSet<T, S> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::Table(lua.create_table_from(
             self.into_iter().map(|val| (val, true)),
         )?))
     }
 }
 
-impl<'lua, T: Eq + Hash + FromLua<'lua>, S: BuildHasher + Default> FromLua<'lua> for HashSet<T, S> {
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+impl<'lua, T: Eq + Hash + FromLua, S: BuildHasher + Default> FromLua for HashSet<T, S> {
+    fn from_lua(value: Value, _: &Lua) -> Result<Self> {
         match value {
             Value::Table(table) if table.len()? > 0 => table.sequence_values().collect(),
             Value::Table(table) => table
-                .pairs::<T, Value<'lua>>()
+                .pairs::<T, Value>()
                 .map(|res| res.map(|(k, _)| k))
                 .collect(),
             _ => Err(Error::FromLuaConversionError {
@@ -601,20 +601,20 @@ impl<'lua, T: Eq + Hash + FromLua<'lua>, S: BuildHasher + Default> FromLua<'lua>
     }
 }
 
-impl<'lua, T: Ord + ToLua<'lua>> ToLua<'lua> for BTreeSet<T> {
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+impl<'lua, T: Ord + ToLua> ToLua for BTreeSet<T> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         Ok(Value::Table(lua.create_table_from(
             self.into_iter().map(|val| (val, true)),
         )?))
     }
 }
 
-impl<'lua, T: Ord + FromLua<'lua>> FromLua<'lua> for BTreeSet<T> {
-    fn from_lua(value: Value<'lua>, _: &'lua Lua) -> Result<Self> {
+impl<'lua, T: Ord + FromLua> FromLua for BTreeSet<T> {
+    fn from_lua(value: Value, _: &Lua) -> Result<Self> {
         match value {
             Value::Table(table) if table.len()? > 0 => table.sequence_values().collect(),
             Value::Table(table) => table
-                .pairs::<T, Value<'lua>>()
+                .pairs::<T, Value>()
                 .map(|res| res.map(|(k, _)| k))
                 .collect(),
             _ => Err(Error::FromLuaConversionError {
@@ -626,9 +626,9 @@ impl<'lua, T: Ord + FromLua<'lua>> FromLua<'lua> for BTreeSet<T> {
     }
 }
 
-impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Option<T> {
+impl<'lua, T: ToLua> ToLua for Option<T> {
     #[inline]
-    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+    fn to_lua(self, lua: &Lua) -> Result<Value> {
         match self {
             Some(val) => val.to_lua(lua),
             None => Ok(Nil),
@@ -636,9 +636,9 @@ impl<'lua, T: ToLua<'lua>> ToLua<'lua> for Option<T> {
     }
 }
 
-impl<'lua, T: FromLua<'lua>> FromLua<'lua> for Option<T> {
+impl<'lua, T: FromLua> FromLua for Option<T> {
     #[inline]
-    fn from_lua(value: Value<'lua>, lua: &'lua Lua) -> Result<Self> {
+    fn from_lua(value: Value, lua: &Lua) -> Result<Self> {
         match value {
             Nil => Ok(None),
             value => Ok(Some(T::from_lua(value, lua)?)),

--- a/src/error.rs
+++ b/src/error.rs
@@ -178,6 +178,7 @@ pub enum Error {
     /// error. The Rust code that originally invoked the Lua code then receives a `CallbackError`,
     /// from which the original error (and a stack traceback) can be recovered.
     ExternalError(Arc<dyn StdError + Send + Sync>),
+    LuaUnavailable
 }
 
 /// A specialized `Result` type used by `mlua`'s API.
@@ -283,6 +284,7 @@ impl fmt::Display for Error {
                 write!(fmt, "deserialize error: {}", err)
             },
             Error::ExternalError(ref err) => write!(fmt, "{}", err),
+            Error::LuaUnavailable => write!(fmt, "lua unavailable")
         }
     }
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -16,25 +16,25 @@ use crate::lua::Lua;
 ///
 /// [lua_doc]: https://www.lua.org/manual/5.4/manual.html#lua_Debug
 /// [`Lua::set_hook`]: crate::Lua::set_hook
-pub struct Debug<'lua> {
-    lua: &'lua Lua,
+pub struct Debug {
+    lua: Lua,
     ar: ActivationRecord,
     #[cfg(feature = "luau")]
     level: c_int,
 }
 
-impl<'lua> Debug<'lua> {
+impl Debug {
     #[cfg(not(feature = "luau"))]
-    pub(crate) fn new(lua: &'lua Lua, ar: *mut lua_Debug) -> Self {
+    pub(crate) fn new(lua: &Lua, ar: *mut lua_Debug) -> Self {
         Debug {
-            lua,
+            lua: lua.clone(),
             ar: ActivationRecord::Borrowed(ar),
         }
     }
 
-    pub(crate) fn new_owned(lua: &'lua Lua, _level: c_int, ar: lua_Debug) -> Self {
+    pub(crate) fn new_owned(lua: &Lua, _level: c_int, ar: lua_Debug) -> Self {
         Debug {
-            lua,
+            lua: lua.clone(),
             ar: ActivationRecord::Owned(UnsafeCell::new(ar)),
             #[cfg(feature = "luau")]
             level: _level,
@@ -63,7 +63,7 @@ impl<'lua> Debug<'lua> {
     }
 
     /// Corresponds to the `n` what mask.
-    pub fn names(&self) -> DebugNames<'lua> {
+    pub fn names(&self) -> DebugNames {
         unsafe {
             #[cfg(not(feature = "luau"))]
             mlua_assert!(
@@ -87,7 +87,7 @@ impl<'lua> Debug<'lua> {
     }
 
     /// Corresponds to the `S` what mask.
-    pub fn source(&self) -> DebugSource<'lua> {
+    pub fn source(&self) -> DebugSource {
         unsafe {
             #[cfg(not(feature = "luau"))]
             mlua_assert!(

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -69,6 +69,7 @@ use serde::Serialize;
 #[derive(Clone)]
 pub struct Lua(Arc<UnsafeCell<LuaInner>>);
 
+#[derive(Debug)]
 pub struct LuaWeakRef(Weak<UnsafeCell<LuaInner>>);
 
 impl LuaWeakRef {

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -8,7 +8,7 @@ use std::mem::ManuallyDrop;
 use std::ops::{Deref, DerefMut};
 use std::os::raw::{c_char, c_int, c_void};
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe, Location};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::{mem, ptr, str};
 
 use rustc_hash::FxHashMap;
@@ -24,16 +24,16 @@ use crate::string::String;
 use crate::table::Table;
 use crate::thread::Thread;
 use crate::types::{
-    Callback, CallbackUpvalue, DestructedUserdataMT, Integer, LightUserData, LuaRef, MaybeSend,
-    Number, RegistryKey,
+	Callback, CallbackUpvalue, DestructedUserdataMT, Integer, LightUserData, LuaRef, MaybeSend,
+	Number, RegistryKey,
 };
 use crate::userdata::{AnyUserData, UserData, UserDataCell};
 use crate::userdata_impl::{StaticUserDataFields, StaticUserDataMethods};
 use crate::util::{
-    self, assert_stack, callback_error, check_stack, get_destructed_userdata_metatable,
-    get_gc_metatable, get_gc_userdata, get_main_state, get_userdata, init_error_registry,
-    init_gc_metatable, init_userdata_metatable, pop_error, push_gc_userdata, push_string,
-    push_table, rawset_field, safe_pcall, safe_xpcall, StackGuard, WrappedFailure,
+	self, assert_stack, callback_error, check_stack, get_destructed_userdata_metatable,
+	get_gc_metatable, get_gc_userdata, get_main_state, get_userdata, init_error_registry,
+	init_gc_metatable, init_userdata_metatable, pop_error, push_gc_userdata, push_string,
+	push_table, rawset_field, safe_pcall, safe_xpcall, StackGuard, WrappedFailure,
 };
 use crate::value::{FromLua, FromLuaMulti, MultiValue, Nil, ToLua, ToLuaMulti, Value};
 
@@ -52,13 +52,13 @@ use crate::{chunk::Compiler, types::VmState};
 
 #[cfg(feature = "async")]
 use {
-    crate::types::{AsyncCallback, AsyncCallbackUpvalue, AsyncPollUpvalue},
-    futures_core::{
-        future::{Future, LocalBoxFuture},
-        task::{Context, Poll, Waker},
-    },
-    futures_task::noop_waker,
-    futures_util::future::{self, TryFutureExt},
+	crate::types::{AsyncCallback, AsyncCallbackUpvalue, AsyncPollUpvalue},
+	futures_core::{
+		future::{Future, LocalBoxFuture},
+		task::{Context, Poll, Waker},
+	},
+	futures_task::noop_waker,
+	futures_util::future::{self, TryFutureExt},
 };
 
 #[cfg(feature = "serialize")]
@@ -66,69 +66,90 @@ use serde::Serialize;
 
 /// Top level Lua struct which represents an instance of Lua VM.
 #[repr(transparent)]
+#[derive(Clone)]
 pub struct Lua(Arc<UnsafeCell<LuaInner>>);
+
+pub struct LuaWeakRef(Weak<UnsafeCell<LuaInner>>);
+
+impl LuaWeakRef {
+	pub(crate) fn new(lua: &Lua) -> LuaWeakRef {
+		LuaWeakRef(Arc::downgrade(&lua.0))
+	}
+	pub(crate) fn optional(&self) -> Result<Lua> {
+		self.0.upgrade().map(|value| { Lua(value) }).ok_or(Error::LuaUnavailable)
+	}
+
+	pub(crate) fn required(&self) -> Lua {
+		match self.0.upgrade() {
+			Some(value) => Lua(value),
+			None => {
+				panic!("Lua is unavailable.")
+			}
+		}
+	}
+}
 
 /// An inner Lua struct which holds a raw Lua state.
 pub struct LuaInner {
-    pub(crate) state: *mut ffi::lua_State,
-    main_state: *mut ffi::lua_State,
-    extra: Arc<UnsafeCell<ExtraData>>,
-    safe: bool,
-    #[cfg(feature = "luau")]
-    compiler: Option<Compiler>,
-    // Lua has lots of interior mutability, should not be RefUnwindSafe
-    _no_ref_unwind_safe: PhantomData<UnsafeCell<()>>,
+	pub(crate) state: *mut ffi::lua_State,
+	main_state: *mut ffi::lua_State,
+	extra: Arc<UnsafeCell<ExtraData>>,
+	safe: bool,
+	#[cfg(feature = "luau")]
+	compiler: Option<Compiler>,
+	// Lua has lots of interior mutability, should not be RefUnwindSafe
+	_no_ref_unwind_safe: PhantomData<UnsafeCell<()>>,
 }
 
 // Data associated with the Lua.
 pub(crate) struct ExtraData {
-    // Same layout as `Lua`
-    inner: Option<ManuallyDrop<Arc<UnsafeCell<LuaInner>>>>,
+	// Same layout as `Lua`
+	inner: Option<ManuallyDrop<Arc<UnsafeCell<LuaInner>>>>,
 
-    registered_userdata: FxHashMap<TypeId, c_int>,
-    registered_userdata_mt: FxHashMap<*const c_void, Option<TypeId>>,
-    registry_unref_list: Arc<Mutex<Option<Vec<c_int>>>>,
+	registered_userdata: FxHashMap<TypeId, c_int>,
+	registered_userdata_mt: FxHashMap<*const c_void, Option<TypeId>>,
+	registry_unref_list: Arc<Mutex<Option<Vec<c_int>>>>,
 
-    #[cfg(not(feature = "send"))]
-    app_data: RefCell<HashMap<TypeId, Box<dyn Any>>>,
-    #[cfg(feature = "send")]
-    app_data: RefCell<HashMap<TypeId, Box<dyn Any + Send>>>,
+	#[cfg(not(feature = "send"))]
+	app_data: RefCell<HashMap<TypeId, Box<dyn Any>>>,
+	#[cfg(feature = "send")]
+	app_data: RefCell<HashMap<TypeId, Box<dyn Any + Send>>>,
 
-    libs: StdLib,
-    mem_info: Option<ptr::NonNull<MemoryInfo>>,
+	libs: StdLib,
+	mem_info: Option<ptr::NonNull<MemoryInfo>>,
 
-    ref_thread: *mut ffi::lua_State,
-    ref_stack_size: c_int,
-    ref_stack_top: c_int,
-    ref_free: Vec<c_int>,
+	ref_thread: *mut ffi::lua_State,
+	ref_stack_size: c_int,
+	ref_stack_top: c_int,
+	ref_free: Vec<c_int>,
 
-    // Cache of `WrappedFailure` enums on the ref thread (as userdata)
-    wrapped_failures_cache: Vec<c_int>,
-    // Cache of recycled `MultiValue` containers
-    multivalue_cache: Vec<MultiValue<'static>>,
-    // Cache of recycled `Thread`s (coroutines)
-    #[cfg(feature = "async")]
-    recycled_thread_cache: Vec<c_int>,
+	// Cache of `WrappedFailure` enums on the ref thread (as userdata)
+	wrapped_failures_cache: Vec<c_int>,
+	// Cache of recycled `MultiValue` containers
+	multivalue_cache: Vec<MultiValue>,
+	// Cache of recycled `Thread`s (coroutines)
+	#[cfg(feature = "async")]
+	recycled_thread_cache: Vec<c_int>,
 
-    // Index of `Option<Waker>` userdata on the ref thread
-    #[cfg(feature = "async")]
-    ref_waker_idx: c_int,
+	// Index of `Option<Waker>` userdata on the ref thread
+	#[cfg(feature = "async")]
+	ref_waker_idx: c_int,
 
-    #[cfg(not(feature = "luau"))]
-    hook_callback: Option<HookCallback>,
-    #[cfg(feature = "lua54")]
-    warn_callback: Option<WarnCallback>,
-    #[cfg(feature = "luau")]
-    interrupt_callback: Option<InterruptCallback>,
+	#[cfg(not(feature = "luau"))]
+	hook_callback: Option<HookCallback>,
+	#[cfg(feature = "lua54")]
+	warn_callback: Option<WarnCallback>,
+	#[cfg(feature = "luau")]
+	interrupt_callback: Option<InterruptCallback>,
 
-    #[cfg(feature = "luau")]
-    sandboxed: bool,
+	#[cfg(feature = "luau")]
+	sandboxed: bool,
 }
 
 #[cfg_attr(any(feature = "lua51", feature = "luajit"), allow(dead_code))]
 struct MemoryInfo {
-    used_memory: isize,
-    memory_limit: isize,
+	used_memory: isize,
+	memory_limit: isize,
 }
 
 /// Mode of the Lua garbage collector (GC).
@@ -141,79 +162,79 @@ struct MemoryInfo {
 /// [documentation]: https://www.lua.org/manual/5.4/manual.html#2.5
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum GCMode {
-    Incremental,
-    /// Requires `feature = "lua54"`
-    #[cfg(any(feature = "lua54"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
-    Generational,
+	Incremental,
+	/// Requires `feature = "lua54"`
+	#[cfg(any(feature = "lua54"))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
+	Generational,
 }
 
 /// Controls Lua interpreter behavior such as Rust panics handling.
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct LuaOptions {
-    /// Catch Rust panics when using [`pcall`]/[`xpcall`].
-    ///
-    /// If disabled, wraps these functions and automatically resumes panic if found.
-    /// Also in Lua 5.1 adds ability to provide arguments to [`xpcall`] similar to Lua >= 5.2.
-    ///
-    /// If enabled, keeps [`pcall`]/[`xpcall`] unmodified.
-    /// Panics are still automatically resumed if returned to the Rust side.
-    ///
-    /// Default: **true**
-    ///
-    /// [`pcall`]: https://www.lua.org/manual/5.4/manual.html#pdf-pcall
-    /// [`xpcall`]: https://www.lua.org/manual/5.4/manual.html#pdf-xpcall
-    pub catch_rust_panics: bool,
+	/// Catch Rust panics when using [`pcall`]/[`xpcall`].
+	///
+	/// If disabled, wraps these functions and automatically resumes panic if found.
+	/// Also in Lua 5.1 adds ability to provide arguments to [`xpcall`] similar to Lua >= 5.2.
+	///
+	/// If enabled, keeps [`pcall`]/[`xpcall`] unmodified.
+	/// Panics are still automatically resumed if returned to the Rust side.
+	///
+	/// Default: **true**
+	///
+	/// [`pcall`]: https://www.lua.org/manual/5.4/manual.html#pdf-pcall
+	/// [`xpcall`]: https://www.lua.org/manual/5.4/manual.html#pdf-xpcall
+	pub catch_rust_panics: bool,
 
-    /// Max size of thread (coroutine) object cache used to execute asynchronous functions.
-    ///
-    /// It works on Lua 5.4, LuaJIT (vendored) and Luau, where [`lua_resetthread`] function
-    /// is available and allows to reuse old coroutines with reset state.
-    ///
-    /// Default: **0** (disabled)
-    ///
-    /// [`lua_resetthread`]: https://www.lua.org/manual/5.4/manual.html#lua_resetthread
-    #[cfg(feature = "async")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-    pub thread_cache_size: usize,
+	/// Max size of thread (coroutine) object cache used to execute asynchronous functions.
+	///
+	/// It works on Lua 5.4, LuaJIT (vendored) and Luau, where [`lua_resetthread`] function
+	/// is available and allows to reuse old coroutines with reset state.
+	///
+	/// Default: **0** (disabled)
+	///
+	/// [`lua_resetthread`]: https://www.lua.org/manual/5.4/manual.html#lua_resetthread
+	#[cfg(feature = "async")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+	pub thread_cache_size: usize,
 }
 
 impl Default for LuaOptions {
-    fn default() -> Self {
-        LuaOptions::new()
-    }
+	fn default() -> Self {
+		LuaOptions::new()
+	}
 }
 
 impl LuaOptions {
-    /// Returns a new instance of `LuaOptions` with default parameters.
-    pub const fn new() -> Self {
-        LuaOptions {
-            catch_rust_panics: true,
-            #[cfg(feature = "async")]
-            thread_cache_size: 0,
-        }
-    }
+	/// Returns a new instance of `LuaOptions` with default parameters.
+	pub const fn new() -> Self {
+		LuaOptions {
+			catch_rust_panics: true,
+			#[cfg(feature = "async")]
+			thread_cache_size: 0,
+		}
+	}
 
-    /// Sets [`catch_rust_panics`] option.
-    ///
-    /// [`catch_rust_panics`]: #structfield.catch_rust_panics
-    #[must_use]
-    pub const fn catch_rust_panics(mut self, enabled: bool) -> Self {
-        self.catch_rust_panics = enabled;
-        self
-    }
+	/// Sets [`catch_rust_panics`] option.
+	///
+	/// [`catch_rust_panics`]: #structfield.catch_rust_panics
+	#[must_use]
+	pub const fn catch_rust_panics(mut self, enabled: bool) -> Self {
+		self.catch_rust_panics = enabled;
+		self
+	}
 
-    /// Sets [`thread_cache_size`] option.
-    ///
-    /// [`thread_cache_size`]: #structfield.thread_cache_size
-    #[cfg(feature = "async")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-    #[must_use]
-    pub const fn thread_cache_size(mut self, size: usize) -> Self {
-        self.thread_cache_size = size;
-        self
-    }
+	/// Sets [`thread_cache_size`] option.
+	///
+	/// [`thread_cache_size`]: #structfield.thread_cache_size
+	#[cfg(feature = "async")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+	#[must_use]
+	pub const fn thread_cache_size(mut self, size: usize) -> Self {
+		self.thread_cache_size = size;
+		self
+	}
 }
 
 #[cfg(feature = "async")]
@@ -230,244 +251,244 @@ unsafe impl Send for LuaInner {}
 
 #[cfg(not(feature = "module"))]
 impl Drop for LuaInner {
-    fn drop(&mut self) {
-        unsafe {
-            let extra = &mut *self.extra.get();
-            let drain_iter = extra.wrapped_failures_cache.drain(..);
-            #[cfg(feature = "async")]
-            let drain_iter = drain_iter.chain(extra.recycled_thread_cache.drain(..));
-            for index in drain_iter {
-                ffi::lua_pushnil(extra.ref_thread);
-                ffi::lua_replace(extra.ref_thread, index);
-                extra.ref_free.push(index);
-            }
-            #[cfg(feature = "async")]
-            {
-                // Destroy Waker slot
-                ffi::lua_pushnil(extra.ref_thread);
-                ffi::lua_replace(extra.ref_thread, extra.ref_waker_idx);
-                extra.ref_free.push(extra.ref_waker_idx);
-            }
-            #[cfg(feature = "luau")]
-            {
-                let callbacks = ffi::lua_callbacks(self.state);
-                let extra_ptr = (*callbacks).userdata as *mut Arc<UnsafeCell<ExtraData>>;
-                drop(Box::from_raw(extra_ptr));
-                (*callbacks).userdata = ptr::null_mut();
-            }
-            mlua_debug_assert!(
+	fn drop(&mut self) {
+		unsafe {
+			let extra = &mut *self.extra.get();
+			let drain_iter = extra.wrapped_failures_cache.drain(..);
+			#[cfg(feature = "async")]
+				let drain_iter = drain_iter.chain(extra.recycled_thread_cache.drain(..));
+			for index in drain_iter {
+				ffi::lua_pushnil(extra.ref_thread);
+				ffi::lua_replace(extra.ref_thread, index);
+				extra.ref_free.push(index);
+			}
+			#[cfg(feature = "async")]
+			{
+				// Destroy Waker slot
+				ffi::lua_pushnil(extra.ref_thread);
+				ffi::lua_replace(extra.ref_thread, extra.ref_waker_idx);
+				extra.ref_free.push(extra.ref_waker_idx);
+			}
+			#[cfg(feature = "luau")]
+			{
+				let callbacks = ffi::lua_callbacks(self.state);
+				let extra_ptr = (*callbacks).userdata as *mut Arc<UnsafeCell<ExtraData>>;
+				drop(Box::from_raw(extra_ptr));
+				(*callbacks).userdata = ptr::null_mut();
+			}
+			mlua_debug_assert!(
                 ffi::lua_gettop(extra.ref_thread) == extra.ref_stack_top
                     && extra.ref_stack_top as usize == extra.ref_free.len(),
                 "reference leak detected"
             );
-            ffi::lua_close(self.main_state);
-        }
-    }
+			ffi::lua_close(self.main_state);
+		}
+	}
 }
 
 impl Drop for ExtraData {
-    fn drop(&mut self) {
-        #[cfg(feature = "module")]
-        unsafe {
-            ManuallyDrop::drop(&mut self.inner.take().unwrap())
-        };
+	fn drop(&mut self) {
+		#[cfg(feature = "module")]
+		unsafe {
+			ManuallyDrop::drop(&mut self.inner.take().unwrap())
+		};
 
-        *mlua_expect!(self.registry_unref_list.lock(), "unref list poisoned") = None;
-        if let Some(mem_info) = self.mem_info {
-            drop(unsafe { Box::from_raw(mem_info.as_ptr()) });
-        }
-    }
+		*mlua_expect!(self.registry_unref_list.lock(), "unref list poisoned") = None;
+		if let Some(mem_info) = self.mem_info {
+			drop(unsafe { Box::from_raw(mem_info.as_ptr()) });
+		}
+	}
 }
 
 impl fmt::Debug for Lua {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Lua({:p})", self.state)
-    }
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		write!(f, "Lua({:p})", self.state)
+	}
 }
 
 impl Deref for Lua {
-    type Target = LuaInner;
+	type Target = LuaInner;
 
-    fn deref(&self) -> &Self::Target {
-        unsafe { &*(*self.0).get() }
-    }
+	fn deref(&self) -> &Self::Target {
+		unsafe { &*(*self.0).get() }
+	}
 }
 
 impl DerefMut for Lua {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        unsafe { &mut *(*self.0).get() }
-    }
+	fn deref_mut(&mut self) -> &mut Self::Target {
+		unsafe { &mut *(*self.0).get() }
+	}
 }
 
 impl Lua {
-    /// Creates a new Lua state and loads the **safe** subset of the standard libraries.
-    ///
-    /// # Safety
-    /// The created Lua state would have _some_ safety guarantees and would not allow to load unsafe
-    /// standard libraries or C modules.
-    ///
-    /// See [`StdLib`] documentation for a list of unsafe modules that cannot be loaded.
-    ///
-    /// [`StdLib`]: crate::StdLib
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Lua {
-        mlua_expect!(
+	/// Creates a new Lua state and loads the **safe** subset of the standard libraries.
+	///
+	/// # Safety
+	/// The created Lua state would have _some_ safety guarantees and would not allow to load unsafe
+	/// standard libraries or C modules.
+	///
+	/// See [`StdLib`] documentation for a list of unsafe modules that cannot be loaded.
+	///
+	/// [`StdLib`]: crate::StdLib
+	#[allow(clippy::new_without_default)]
+	pub fn new() -> Lua {
+		mlua_expect!(
             Self::new_with(StdLib::ALL_SAFE, LuaOptions::default()),
             "can't create new safe Lua state"
         )
-    }
+	}
 
-    /// Creates a new Lua state and loads all the standard libraries.
-    ///
-    /// # Safety
-    /// The created Lua state would not have safety guarantees and would allow to load C modules.
-    pub unsafe fn unsafe_new() -> Lua {
-        Self::unsafe_new_with(StdLib::ALL, LuaOptions::default())
-    }
+	/// Creates a new Lua state and loads all the standard libraries.
+	///
+	/// # Safety
+	/// The created Lua state would not have safety guarantees and would allow to load C modules.
+	pub unsafe fn unsafe_new() -> Lua {
+		Self::unsafe_new_with(StdLib::ALL, LuaOptions::default())
+	}
 
-    /// Creates a new Lua state and loads the specified safe subset of the standard libraries.
-    ///
-    /// Use the [`StdLib`] flags to specify the libraries you want to load.
-    ///
-    /// # Safety
-    /// The created Lua state would have _some_ safety guarantees and would not allow to load unsafe
-    /// standard libraries or C modules.
-    ///
-    /// See [`StdLib`] documentation for a list of unsafe modules that cannot be loaded.
-    ///
-    /// [`StdLib`]: crate::StdLib
-    pub fn new_with(libs: StdLib, options: LuaOptions) -> Result<Lua> {
-        #[cfg(not(feature = "luau"))]
-        if libs.contains(StdLib::DEBUG) {
-            return Err(Error::SafetyError(
-                "the unsafe `debug` module can't be loaded using safe `new_with`".to_string(),
-            ));
-        }
-        #[cfg(feature = "luajit")]
-        {
-            if libs.contains(StdLib::FFI) {
-                return Err(Error::SafetyError(
-                    "the unsafe `ffi` module can't be loaded using safe `new_with`".to_string(),
-                ));
-            }
-        }
+	/// Creates a new Lua state and loads the specified safe subset of the standard libraries.
+	///
+	/// Use the [`StdLib`] flags to specify the libraries you want to load.
+	///
+	/// # Safety
+	/// The created Lua state would have _some_ safety guarantees and would not allow to load unsafe
+	/// standard libraries or C modules.
+	///
+	/// See [`StdLib`] documentation for a list of unsafe modules that cannot be loaded.
+	///
+	/// [`StdLib`]: crate::StdLib
+	pub fn new_with(libs: StdLib, options: LuaOptions) -> Result<Lua> {
+		#[cfg(not(feature = "luau"))]
+		if libs.contains(StdLib::DEBUG) {
+			return Err(Error::SafetyError(
+				"the unsafe `debug` module can't be loaded using safe `new_with`".to_string(),
+			));
+		}
+		#[cfg(feature = "luajit")]
+		{
+			if libs.contains(StdLib::FFI) {
+				return Err(Error::SafetyError(
+					"the unsafe `ffi` module can't be loaded using safe `new_with`".to_string(),
+				));
+			}
+		}
 
-        let mut lua = unsafe { Self::inner_new(libs, options) };
+		let mut lua = unsafe { Self::inner_new(libs, options) };
 
-        #[cfg(not(feature = "luau"))]
-        if libs.contains(StdLib::PACKAGE) {
-            mlua_expect!(lua.disable_c_modules(), "Error during disabling C modules");
-        }
-        lua.safe = true;
+		#[cfg(not(feature = "luau"))]
+		if libs.contains(StdLib::PACKAGE) {
+			mlua_expect!(lua.disable_c_modules(), "Error during disabling C modules");
+		}
+		lua.safe = true;
 
-        Ok(lua)
-    }
+		Ok(lua)
+	}
 
-    /// Creates a new Lua state and loads the specified subset of the standard libraries.
-    ///
-    /// Use the [`StdLib`] flags to specify the libraries you want to load.
-    ///
-    /// # Safety
-    /// The created Lua state will not have safety guarantees and allow to load C modules.
-    ///
-    /// [`StdLib`]: crate::StdLib
-    pub unsafe fn unsafe_new_with(libs: StdLib, options: LuaOptions) -> Lua {
-        #[cfg(not(feature = "luau"))]
-        ffi::keep_lua_symbols();
-        Self::inner_new(libs, options)
-    }
+	/// Creates a new Lua state and loads the specified subset of the standard libraries.
+	///
+	/// Use the [`StdLib`] flags to specify the libraries you want to load.
+	///
+	/// # Safety
+	/// The created Lua state will not have safety guarantees and allow to load C modules.
+	///
+	/// [`StdLib`]: crate::StdLib
+	pub unsafe fn unsafe_new_with(libs: StdLib, options: LuaOptions) -> Lua {
+		#[cfg(not(feature = "luau"))]
+		ffi::keep_lua_symbols();
+		Self::inner_new(libs, options)
+	}
 
-    unsafe fn inner_new(libs: StdLib, options: LuaOptions) -> Lua {
-        #[cfg_attr(
-            any(feature = "lua51", feature = "luajit", feature = "luau"),
-            allow(dead_code)
-        )]
-        unsafe extern "C" fn allocator(
-            extra_data: *mut c_void,
-            ptr: *mut c_void,
-            osize: usize,
-            nsize: usize,
-        ) -> *mut c_void {
-            use std::alloc;
+	unsafe fn inner_new(libs: StdLib, options: LuaOptions) -> Lua {
+		#[cfg_attr(
+		any(feature = "lua51", feature = "luajit", feature = "luau"),
+		allow(dead_code)
+		)]
+		unsafe extern "C" fn allocator(
+			extra_data: *mut c_void,
+			ptr: *mut c_void,
+			osize: usize,
+			nsize: usize,
+		) -> *mut c_void {
+			use std::alloc;
 
-            let mem_info = &mut *(extra_data as *mut MemoryInfo);
+			let mem_info = &mut *(extra_data as *mut MemoryInfo);
 
-            if nsize == 0 {
-                // Free memory
-                if !ptr.is_null() {
-                    let layout =
-                        alloc::Layout::from_size_align_unchecked(osize, ffi::SYS_MIN_ALIGN);
-                    alloc::dealloc(ptr as *mut u8, layout);
-                    mem_info.used_memory -= osize as isize;
-                }
-                return ptr::null_mut();
-            }
+			if nsize == 0 {
+				// Free memory
+				if !ptr.is_null() {
+					let layout =
+						alloc::Layout::from_size_align_unchecked(osize, ffi::SYS_MIN_ALIGN);
+					alloc::dealloc(ptr as *mut u8, layout);
+					mem_info.used_memory -= osize as isize;
+				}
+				return ptr::null_mut();
+			}
 
-            // Are we fit to the memory limits?
-            let mut mem_diff = nsize as isize;
-            if !ptr.is_null() {
-                mem_diff -= osize as isize;
-            }
-            let new_used_memory = mem_info.used_memory + mem_diff;
-            if mem_info.memory_limit > 0 && new_used_memory > mem_info.memory_limit {
-                return ptr::null_mut();
-            }
+			// Are we fit to the memory limits?
+			let mut mem_diff = nsize as isize;
+			if !ptr.is_null() {
+				mem_diff -= osize as isize;
+			}
+			let new_used_memory = mem_info.used_memory + mem_diff;
+			if mem_info.memory_limit > 0 && new_used_memory > mem_info.memory_limit {
+				return ptr::null_mut();
+			}
 
-            let new_layout = alloc::Layout::from_size_align_unchecked(nsize, ffi::SYS_MIN_ALIGN);
+			let new_layout = alloc::Layout::from_size_align_unchecked(nsize, ffi::SYS_MIN_ALIGN);
 
-            if ptr.is_null() {
-                // Allocate new memory
-                let new_ptr = alloc::alloc(new_layout) as *mut c_void;
-                if !new_ptr.is_null() {
-                    mem_info.used_memory += mem_diff;
-                }
-                return new_ptr;
-            }
+			if ptr.is_null() {
+				// Allocate new memory
+				let new_ptr = alloc::alloc(new_layout) as *mut c_void;
+				if !new_ptr.is_null() {
+					mem_info.used_memory += mem_diff;
+				}
+				return new_ptr;
+			}
 
-            // Reallocate memory
-            let old_layout = alloc::Layout::from_size_align_unchecked(osize, ffi::SYS_MIN_ALIGN);
-            let new_ptr = alloc::realloc(ptr as *mut u8, old_layout, nsize) as *mut c_void;
+			// Reallocate memory
+			let old_layout = alloc::Layout::from_size_align_unchecked(osize, ffi::SYS_MIN_ALIGN);
+			let new_ptr = alloc::realloc(ptr as *mut u8, old_layout, nsize) as *mut c_void;
 
-            if !new_ptr.is_null() {
-                mem_info.used_memory += mem_diff;
-            } else if !ptr.is_null() && nsize < osize {
-                // Should not happen
-                alloc::handle_alloc_error(new_layout);
-            }
+			if !new_ptr.is_null() {
+				mem_info.used_memory += mem_diff;
+			} else if !ptr.is_null() && nsize < osize {
+				// Should not happen
+				alloc::handle_alloc_error(new_layout);
+			}
 
-            new_ptr
-        }
+			new_ptr
+		}
 
-        #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
-        let mem_info = Box::into_raw(Box::new(MemoryInfo {
-            used_memory: 0,
-            memory_limit: 0,
-        }));
+		#[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
+			let mem_info = Box::into_raw(Box::new(MemoryInfo {
+			used_memory: 0,
+			memory_limit: 0,
+		}));
 
-        #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
-        let state = ffi::lua_newstate(allocator, mem_info as *mut c_void);
-        #[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
-        let state = ffi::luaL_newstate();
+		#[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
+			let state = ffi::lua_newstate(allocator, mem_info as *mut c_void);
+		#[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
+			let state = ffi::luaL_newstate();
 
-        ffi::luaL_requiref(state, cstr!("_G"), ffi::luaopen_base, 1);
-        ffi::lua_pop(state, 1);
+		ffi::luaL_requiref(state, cstr!("_G"), ffi::luaopen_base, 1);
+		ffi::lua_pop(state, 1);
 
-        let lua = Lua::init_from_ptr(state);
-        let extra = &mut *lua.extra.get();
+		let lua = Lua::init_from_ptr(state);
+		let extra = &mut *lua.extra.get();
 
-        #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
-        {
-            extra.mem_info = ptr::NonNull::new(mem_info);
-        }
+		#[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
+		{
+			extra.mem_info = ptr::NonNull::new(mem_info);
+		}
 
-        mlua_expect!(
+		mlua_expect!(
             load_from_std_lib(state, libs),
             "Error during loading standard libraries"
         );
-        extra.libs |= libs;
+		extra.libs |= libs;
 
-        if !options.catch_rust_panics {
-            mlua_expect!(
+		if !options.catch_rust_panics {
+			mlua_expect!(
                 (|| -> Result<()> {
                     let _sg = StackGuard::new(lua.state);
 
@@ -486,33 +507,33 @@ impl Lua {
                 })(),
                 "Error during applying option `catch_rust_panics`"
             )
-        }
+		}
 
-        #[cfg(feature = "async")]
-        if options.thread_cache_size > 0 {
-            extra.recycled_thread_cache = Vec::with_capacity(options.thread_cache_size);
-        }
+		#[cfg(feature = "async")]
+		if options.thread_cache_size > 0 {
+			extra.recycled_thread_cache = Vec::with_capacity(options.thread_cache_size);
+		}
 
-        #[cfg(feature = "luau")]
-        mlua_expect!(lua.prepare_luau_state(), "Error preparing Luau state");
+		#[cfg(feature = "luau")]
+		mlua_expect!(lua.prepare_luau_state(), "Error preparing Luau state");
 
-        lua
-    }
+		lua
+	}
 
-    /// Constructs a new Lua instance from an existing raw state.
-    ///
-    /// Once called, a returned Lua state is cached in the registry and can be retrieved
-    /// by calling this function again.
-    #[allow(clippy::missing_safety_doc)]
-    pub unsafe fn init_from_ptr(state: *mut ffi::lua_State) -> Lua {
-        let main_state = get_main_state(state).unwrap_or(state);
-        let main_state_top = ffi::lua_gettop(main_state);
+	/// Constructs a new Lua instance from an existing raw state.
+	///
+	/// Once called, a returned Lua state is cached in the registry and can be retrieved
+	/// by calling this function again.
+	#[allow(clippy::missing_safety_doc)]
+	pub unsafe fn init_from_ptr(state: *mut ffi::lua_State) -> Lua {
+		let main_state = get_main_state(state).unwrap_or(state);
+		let main_state_top = ffi::lua_gettop(main_state);
 
-        if let Some(lua) = Lua::make_from_ptr(state) {
-            return lua;
-        }
+		if let Some(lua) = Lua::make_from_ptr(state) {
+			return lua;
+		}
 
-        mlua_expect!(
+		mlua_expect!(
             (|state| {
                 init_error_registry(state)?;
 
@@ -539,9 +560,9 @@ impl Lua {
             "Error during Lua construction",
         );
 
-        // Create ref stack thread and place it in the registry to prevent it from being garbage
-        // collected.
-        let ref_thread = mlua_expect!(
+		// Create ref stack thread and place it in the registry to prevent it from being garbage
+		// collected.
+		let ref_thread = mlua_expect!(
             protect_lua!(state, 0, 0, |state| {
                 let thread = ffi::lua_newthread(state);
                 ffi::luaL_ref(state, ffi::LUA_REGISTRYINDEX);
@@ -550,49 +571,49 @@ impl Lua {
             "Error while creating ref thread",
         );
 
-        // Create empty Waker slot on the ref thread
-        #[cfg(feature = "async")]
-        let ref_waker_idx = {
-            mlua_expect!(
+		// Create empty Waker slot on the ref thread
+		#[cfg(feature = "async")]
+			let ref_waker_idx = {
+			mlua_expect!(
                 push_gc_userdata::<Option<Waker>>(ref_thread, None),
                 "Error while creating Waker slot"
             );
-            ffi::lua_gettop(ref_thread)
-        };
-        let ref_stack_top = ffi::lua_gettop(ref_thread);
+			ffi::lua_gettop(ref_thread)
+		};
+		let ref_stack_top = ffi::lua_gettop(ref_thread);
 
-        // Create ExtraData
+		// Create ExtraData
 
-        let extra = Arc::new(UnsafeCell::new(ExtraData {
-            inner: None,
-            registered_userdata: FxHashMap::default(),
-            registered_userdata_mt: FxHashMap::default(),
-            registry_unref_list: Arc::new(Mutex::new(Some(Vec::new()))),
-            app_data: RefCell::new(HashMap::new()),
-            ref_thread,
-            libs: StdLib::NONE,
-            mem_info: None,
-            // We need 1 extra stack space to move values in and out of the ref stack.
-            ref_stack_size: ffi::LUA_MINSTACK - 1,
-            ref_stack_top,
-            ref_free: Vec::new(),
-            wrapped_failures_cache: Vec::with_capacity(WRAPPED_FAILURES_CACHE_SIZE),
-            multivalue_cache: Vec::with_capacity(MULTIVALUE_CACHE_SIZE),
-            #[cfg(feature = "async")]
-            recycled_thread_cache: Vec::new(),
-            #[cfg(feature = "async")]
-            ref_waker_idx,
-            #[cfg(not(feature = "luau"))]
-            hook_callback: None,
-            #[cfg(feature = "lua54")]
-            warn_callback: None,
-            #[cfg(feature = "luau")]
-            interrupt_callback: None,
-            #[cfg(feature = "luau")]
-            sandboxed: false,
-        }));
+		let extra = Arc::new(UnsafeCell::new(ExtraData {
+			inner: None,
+			registered_userdata: FxHashMap::default(),
+			registered_userdata_mt: FxHashMap::default(),
+			registry_unref_list: Arc::new(Mutex::new(Some(Vec::new()))),
+			app_data: RefCell::new(HashMap::new()),
+			ref_thread,
+			libs: StdLib::NONE,
+			mem_info: None,
+			// We need 1 extra stack space to move values in and out of the ref stack.
+			ref_stack_size: ffi::LUA_MINSTACK - 1,
+			ref_stack_top,
+			ref_free: Vec::new(),
+			wrapped_failures_cache: Vec::with_capacity(WRAPPED_FAILURES_CACHE_SIZE),
+			multivalue_cache: Vec::with_capacity(MULTIVALUE_CACHE_SIZE),
+			#[cfg(feature = "async")]
+			recycled_thread_cache: Vec::new(),
+			#[cfg(feature = "async")]
+			ref_waker_idx,
+			#[cfg(not(feature = "luau"))]
+			hook_callback: None,
+			#[cfg(feature = "lua54")]
+			warn_callback: None,
+			#[cfg(feature = "luau")]
+			interrupt_callback: None,
+			#[cfg(feature = "luau")]
+			sandboxed: false,
+		}));
 
-        mlua_expect!(
+		mlua_expect!(
             (|state| {
                 push_gc_userdata(state, Arc::clone(&extra))?;
                 protect_lua!(state, 1, 0, fn(state) {
@@ -603,273 +624,273 @@ impl Lua {
             "Error while storing extra data",
         );
 
-        // Register `DestructedUserdataMT` type
-        get_destructed_userdata_metatable(main_state);
-        let destructed_mt_ptr = ffi::lua_topointer(main_state, -1);
-        let destructed_mt_typeid = Some(TypeId::of::<DestructedUserdataMT>());
-        (*extra.get())
-            .registered_userdata_mt
-            .insert(destructed_mt_ptr, destructed_mt_typeid);
-        ffi::lua_pop(main_state, 1);
+		// Register `DestructedUserdataMT` type
+		get_destructed_userdata_metatable(main_state);
+		let destructed_mt_ptr = ffi::lua_topointer(main_state, -1);
+		let destructed_mt_typeid = Some(TypeId::of::<DestructedUserdataMT>());
+		(*extra.get())
+			.registered_userdata_mt
+			.insert(destructed_mt_ptr, destructed_mt_typeid);
+		ffi::lua_pop(main_state, 1);
 
-        mlua_debug_assert!(
+		mlua_debug_assert!(
             ffi::lua_gettop(main_state) == main_state_top,
             "stack leak during creation"
         );
-        assert_stack(main_state, ffi::LUA_MINSTACK);
+		assert_stack(main_state, ffi::LUA_MINSTACK);
 
-        // Set Luau callbacks userdata to extra data
-        // We can use global callbacks userdata since we don't allow C modules in Luau
-        #[cfg(feature = "luau")]
-        {
-            let extra_raw = Box::into_raw(Box::new(Arc::clone(&extra)));
-            (*ffi::lua_callbacks(main_state)).userdata = extra_raw as *mut c_void;
-        }
+		// Set Luau callbacks userdata to extra data
+		// We can use global callbacks userdata since we don't allow C modules in Luau
+		#[cfg(feature = "luau")]
+		{
+			let extra_raw = Box::into_raw(Box::new(Arc::clone(&extra)));
+			(*ffi::lua_callbacks(main_state)).userdata = extra_raw as *mut c_void;
+		}
 
-        let inner = Arc::new(UnsafeCell::new(LuaInner {
-            state,
-            main_state,
-            extra: Arc::clone(&extra),
-            safe: false,
-            #[cfg(feature = "luau")]
-            compiler: None,
-            _no_ref_unwind_safe: PhantomData,
-        }));
+		let inner = Arc::new(UnsafeCell::new(LuaInner {
+			state,
+			main_state,
+			extra: Arc::clone(&extra),
+			safe: false,
+			#[cfg(feature = "luau")]
+			compiler: None,
+			_no_ref_unwind_safe: PhantomData,
+		}));
 
-        (*extra.get()).inner = Some(ManuallyDrop::new(Arc::clone(&inner)));
-        #[cfg(not(feature = "module"))]
-        Arc::decrement_strong_count(Arc::as_ptr(&inner));
+		(*extra.get()).inner = Some(ManuallyDrop::new(Arc::clone(&inner)));
+		#[cfg(not(feature = "module"))]
+		Arc::decrement_strong_count(Arc::as_ptr(&inner));
 
-        Lua(inner)
-    }
+		Lua(inner)
+	}
 
-    /// Loads the specified subset of the standard libraries into an existing Lua state.
-    ///
-    /// Use the [`StdLib`] flags to specify the libraries you want to load.
-    ///
-    /// [`StdLib`]: crate::StdLib
-    pub fn load_from_std_lib(&self, libs: StdLib) -> Result<()> {
-        #[cfg(not(feature = "luau"))]
-        if self.safe && libs.contains(StdLib::DEBUG) {
-            return Err(Error::SafetyError(
-                "the unsafe `debug` module can't be loaded in safe mode".to_string(),
-            ));
-        }
-        #[cfg(feature = "luajit")]
-        {
-            if self.safe && libs.contains(StdLib::FFI) {
-                return Err(Error::SafetyError(
-                    "the unsafe `ffi` module can't be loaded in safe mode".to_string(),
-                ));
-            }
-        }
+	/// Loads the specified subset of the standard libraries into an existing Lua state.
+	///
+	/// Use the [`StdLib`] flags to specify the libraries you want to load.
+	///
+	/// [`StdLib`]: crate::StdLib
+	pub fn load_from_std_lib(&self, libs: StdLib) -> Result<()> {
+		#[cfg(not(feature = "luau"))]
+		if self.safe && libs.contains(StdLib::DEBUG) {
+			return Err(Error::SafetyError(
+				"the unsafe `debug` module can't be loaded in safe mode".to_string(),
+			));
+		}
+		#[cfg(feature = "luajit")]
+		{
+			if self.safe && libs.contains(StdLib::FFI) {
+				return Err(Error::SafetyError(
+					"the unsafe `ffi` module can't be loaded in safe mode".to_string(),
+				));
+			}
+		}
 
-        let res = unsafe { load_from_std_lib(self.main_state, libs) };
+		let res = unsafe { load_from_std_lib(self.main_state, libs) };
 
-        // If `package` library loaded into a safe lua state then disable C modules
-        let extra = unsafe { &mut *self.extra.get() };
-        #[cfg(not(feature = "luau"))]
-        {
-            let curr_libs = extra.libs;
-            if self.safe && (curr_libs ^ (curr_libs | libs)).contains(StdLib::PACKAGE) {
-                mlua_expect!(self.disable_c_modules(), "Error during disabling C modules");
-            }
-        }
-        extra.libs |= libs;
+		// If `package` library loaded into a safe lua state then disable C modules
+		let extra = unsafe { &mut *self.extra.get() };
+		#[cfg(not(feature = "luau"))]
+		{
+			let curr_libs = extra.libs;
+			if self.safe && (curr_libs ^ (curr_libs | libs)).contains(StdLib::PACKAGE) {
+				mlua_expect!(self.disable_c_modules(), "Error during disabling C modules");
+			}
+		}
+		extra.libs |= libs;
 
-        res
-    }
+		res
+	}
 
-    /// Loads module `modname` into an existing Lua state using the specified entrypoint
-    /// function.
-    ///
-    /// Internally calls the Lua function `func` with the string `modname` as an argument,
-    /// sets the call result to `package.loaded[modname]` and returns copy of the result.
-    ///
-    /// If `package.loaded[modname]` value is not nil, returns copy of the value without
-    /// calling the function.
-    ///
-    /// If the function does not return a non-nil value then this method assigns true to
-    /// `package.loaded[modname]`.
-    ///
-    /// Behavior is similar to Lua's [`require`] function.
-    ///
-    /// [`require`]: https://www.lua.org/manual/5.4/manual.html#pdf-require
-    pub fn load_from_function<'lua, S, T>(
-        &'lua self,
-        modname: &S,
-        func: Function<'lua>,
-    ) -> Result<T>
-    where
-        S: AsRef<[u8]> + ?Sized,
-        T: FromLua<'lua>,
-    {
-        let loaded = unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 2)?;
-            protect_lua!(self.state, 0, 1, fn(state) {
+	/// Loads module `modname` into an existing Lua state using the specified entrypoint
+	/// function.
+	///
+	/// Internally calls the Lua function `func` with the string `modname` as an argument,
+	/// sets the call result to `package.loaded[modname]` and returns copy of the result.
+	///
+	/// If `package.loaded[modname]` value is not nil, returns copy of the value without
+	/// calling the function.
+	///
+	/// If the function does not return a non-nil value then this method assigns true to
+	/// `package.loaded[modname]`.
+	///
+	/// Behavior is similar to Lua's [`require`] function.
+	///
+	/// [`require`]: https://www.lua.org/manual/5.4/manual.html#pdf-require
+	pub fn load_from_function<'lua, S, T>(
+		&'lua self,
+		modname: &S,
+		func: Function,
+	) -> Result<T>
+		where
+			S: AsRef<[u8]> + ?Sized,
+			T: FromLua,
+	{
+		let loaded = unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 2)?;
+			protect_lua!(self.state, 0, 1, fn(state) {
                 ffi::luaL_getsubtable(state, ffi::LUA_REGISTRYINDEX, cstr!("_LOADED"));
             })?;
-            Table(self.pop_ref())
-        };
+			Table(self.pop_ref())
+		};
 
-        let modname = self.create_string(modname)?;
-        let value = match loaded.raw_get(modname.clone())? {
-            Value::Nil => {
-                let result = match func.call(modname.clone())? {
-                    Value::Nil => Value::Boolean(true),
-                    res => res,
-                };
-                loaded.raw_set(modname, result.clone())?;
-                result
-            }
-            res => res,
-        };
-        T::from_lua(value, self)
-    }
+		let modname = self.create_string(modname)?;
+		let value = match loaded.raw_get(modname.clone())? {
+			Value::Nil => {
+				let result = match func.call(modname.clone())? {
+					Value::Nil => Value::Boolean(true),
+					res => res,
+				};
+				loaded.raw_set(modname, result.clone())?;
+				result
+			}
+			res => res,
+		};
+		T::from_lua(value, self)
+	}
 
-    /// Unloads module `modname`.
-    ///
-    /// Removes module from the [`package.loaded`] table which allows to load it again.
-    /// It does not support unloading binary Lua modules since they are internally cached and can be
-    /// unloaded only by closing Lua state.
-    ///
-    /// [`package.loaded`]: https://www.lua.org/manual/5.4/manual.html#pdf-package.loaded
-    pub fn unload<S>(&self, modname: &S) -> Result<()>
-    where
-        S: AsRef<[u8]> + ?Sized,
-    {
-        let loaded = unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 2)?;
-            protect_lua!(self.state, 0, 1, fn(state) {
+	/// Unloads module `modname`.
+	///
+	/// Removes module from the [`package.loaded`] table which allows to load it again.
+	/// It does not support unloading binary Lua modules since they are internally cached and can be
+	/// unloaded only by closing Lua state.
+	///
+	/// [`package.loaded`]: https://www.lua.org/manual/5.4/manual.html#pdf-package.loaded
+	pub fn unload<S>(&self, modname: &S) -> Result<()>
+		where
+			S: AsRef<[u8]> + ?Sized,
+	{
+		let loaded = unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 2)?;
+			protect_lua!(self.state, 0, 1, fn(state) {
                 ffi::luaL_getsubtable(state, ffi::LUA_REGISTRYINDEX, cstr!("_LOADED"));
             })?;
-            Table(self.pop_ref())
-        };
+			Table(self.pop_ref())
+		};
 
-        let modname = self.create_string(modname)?;
-        loaded.raw_remove(modname)?;
-        Ok(())
-    }
+		let modname = self.create_string(modname)?;
+		loaded.raw_remove(modname)?;
+		Ok(())
+	}
 
-    /// Consumes and leaks `Lua` object, returning a static reference `&'static Lua`.
-    ///
-    /// This function is useful when the `Lua` object is supposed to live for the remainder
-    /// of the program's life.
-    /// In particular in asynchronous context this will allow to spawn Lua tasks to execute
-    /// in background.
-    ///
-    /// Dropping the returned reference will cause a memory leak. If this is not acceptable,
-    /// the reference should first be wrapped with the [`Lua::from_static`] function producing a `Lua`.
-    /// This `Lua` object can then be dropped which will properly release the allocated memory.
-    ///
-    /// [`Lua::from_static`]: #method.from_static
-    #[doc(hidden)]
-    pub fn into_static(self) -> &'static Self {
-        Box::leak(Box::new(self))
-    }
+	/// Consumes and leaks `Lua` object, returning a static reference `&'static Lua`.
+	///
+	/// This function is useful when the `Lua` object is supposed to live for the remainder
+	/// of the program's life.
+	/// In particular in asynchronous context this will allow to spawn Lua tasks to execute
+	/// in background.
+	///
+	/// Dropping the returned reference will cause a memory leak. If this is not acceptable,
+	/// the reference should first be wrapped with the [`Lua::from_static`] function producing a `Lua`.
+	/// This `Lua` object can then be dropped which will properly release the allocated memory.
+	///
+	/// [`Lua::from_static`]: #method.from_static
+	#[doc(hidden)]
+	pub fn into_static(self) -> &'static Self {
+		Box::leak(Box::new(self))
+	}
 
-    /// Constructs a `Lua` from a static reference to it.
-    ///
-    /// # Safety
-    /// This function is unsafe because improper use may lead to memory problems or undefined behavior.
-    #[doc(hidden)]
-    pub unsafe fn from_static(lua: &'static Lua) -> Self {
-        *Box::from_raw(lua as *const Lua as *mut Lua)
-    }
+	/// Constructs a `Lua` from a static reference to it.
+	///
+	/// # Safety
+	/// This function is unsafe because improper use may lead to memory problems or undefined behavior.
+	#[doc(hidden)]
+	pub unsafe fn from_static(lua: &'static Lua) -> Self {
+		*Box::from_raw(lua as *const Lua as *mut Lua)
+	}
 
-    // Executes module entrypoint function, which returns only one Value.
-    // The returned value then pushed onto the stack.
-    #[doc(hidden)]
-    #[cfg(not(tarpaulin_include))]
-    pub unsafe fn entrypoint<'lua, A, R, F>(self, func: F) -> Result<c_int>
-    where
-        A: FromLuaMulti<'lua>,
-        R: ToLua<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> Result<R>,
-    {
-        let entrypoint_inner = |lua: &'lua Lua, func: F| {
-            let nargs = ffi::lua_gettop(lua.state);
-            check_stack(lua.state, 3)?;
+	// Executes module entrypoint function, which returns only one Value.
+	// The returned value then pushed onto the stack.
+	#[doc(hidden)]
+	#[cfg(not(tarpaulin_include))]
+	pub unsafe fn entrypoint<'lua, A, R, F>(self, func: F) -> Result<c_int>
+		where
+			A: FromLuaMulti,
+			R: ToLua,
+			F: 'static + MaybeSend + Fn(&Lua, A) -> Result<R>,
+	{
+		let entrypoint_inner = |lua: &Lua, func: F| {
+			let nargs = ffi::lua_gettop(lua.state);
+			check_stack(lua.state, 3)?;
 
-            let mut args = MultiValue::new();
-            args.reserve(nargs as usize);
-            for _ in 0..nargs {
-                args.push_front(lua.pop_value());
-            }
+			let mut args = MultiValue::new();
+			args.reserve(nargs as usize);
+			for _ in 0..nargs {
+				args.push_front(lua.pop_value());
+			}
 
-            // We create callback rather than call `func` directly to catch errors
-            // with attached stacktrace.
-            let callback = lua.create_callback(Box::new(move |lua, args| {
-                func(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            }))?;
-            callback.call(args)
-        };
+			// We create callback rather than call `func` directly to catch errors
+			// with attached stacktrace.
+			let callback = lua.create_callback(Box::new(move |lua, args| {
+				func(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			}))?;
+			callback.call(args)
+		};
 
-        match entrypoint_inner(mem::transmute(&self), func) {
-            Ok(res) => {
-                self.push_value(res)?;
-                Ok(1)
-            }
-            Err(err) => {
-                self.push_value(Value::Error(err))?;
-                let state = self.state;
-                // Lua (self) must be dropped before triggering longjmp
-                drop(self);
-                ffi::lua_error(state)
-            }
-        }
-    }
+		match entrypoint_inner(mem::transmute(&self), func) {
+			Ok(res) => {
+				self.push_value(res)?;
+				Ok(1)
+			}
+			Err(err) => {
+				self.push_value(Value::Error(err))?;
+				let state = self.state;
+				// Lua (self) must be dropped before triggering longjmp
+				drop(self);
+				ffi::lua_error(state)
+			}
+		}
+	}
 
-    // A simple module entrypoint without arguments
-    #[doc(hidden)]
-    #[cfg(not(tarpaulin_include))]
-    pub unsafe fn entrypoint1<'lua, R, F>(self, func: F) -> Result<c_int>
-    where
-        R: ToLua<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua) -> Result<R>,
-    {
-        self.entrypoint(move |lua, _: ()| func(lua))
-    }
+	// A simple module entrypoint without arguments
+	#[doc(hidden)]
+	#[cfg(not(tarpaulin_include))]
+	pub unsafe fn entrypoint1<'lua, R, F>(self, func: F) -> Result<c_int>
+		where
+			R: ToLua,
+			F: 'static + MaybeSend + Fn(&Lua) -> Result<R>,
+	{
+		self.entrypoint(move |lua, _: ()| func(lua))
+	}
 
-    /// Enables (or disables) sandbox mode on this Lua instance.
-    ///
-    /// This method, in particular:
-    /// - Set all libraries to read-only
-    /// - Set all builtin metatables to read-only
-    /// - Set globals to read-only (and activates safeenv)
-    /// - Setup local environment table that performs writes locally and proxies reads
-    ///   to the global environment.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use mlua::{Lua, Result};
-    /// # fn main() -> Result<()> {
-    /// let lua = Lua::new();
-    ///
-    /// lua.sandbox(true)?;
-    /// lua.load("var = 123").exec()?;
-    /// assert_eq!(lua.globals().get::<_, u32>("var")?, 123);
-    ///
-    /// // Restore the global environment (clear changes made in sandbox)
-    /// lua.sandbox(false)?;
-    /// assert_eq!(lua.globals().get::<_, Option<u32>>("var")?, None);
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// Requires `feature = "luau"`
-    #[cfg(any(feature = "luau", docsrs))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
-    pub fn sandbox(&self, enabled: bool) -> Result<()> {
-        unsafe {
-            let extra = &mut *self.extra.get();
-            if extra.sandboxed != enabled {
-                let state = self.main_state;
-                check_stack(state, 3)?;
-                protect_lua!(state, 0, 0, |state| {
+	/// Enables (or disables) sandbox mode on this Lua instance.
+	///
+	/// This method, in particular:
+	/// - Set all libraries to read-only
+	/// - Set all builtin metatables to read-only
+	/// - Set globals to read-only (and activates safeenv)
+	/// - Setup local environment table that performs writes locally and proxies reads
+	///   to the global environment.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// # use mlua::{Lua, Result};
+	/// # fn main() -> Result<()> {
+	/// let lua = Lua::new();
+	///
+	/// lua.sandbox(true)?;
+	/// lua.load("var = 123").exec()?;
+	/// assert_eq!(lua.globals().get::<_, u32>("var")?, 123);
+	///
+	/// // Restore the global environment (clear changes made in sandbox)
+	/// lua.sandbox(false)?;
+	/// assert_eq!(lua.globals().get::<_, Option<u32>>("var")?, None);
+	/// # Ok(())
+	/// # }
+	/// ```
+	///
+	/// Requires `feature = "luau"`
+	#[cfg(any(feature = "luau", docsrs))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
+	pub fn sandbox(&self, enabled: bool) -> Result<()> {
+		unsafe {
+			let extra = &mut *self.extra.get();
+			if extra.sandboxed != enabled {
+				let state = self.main_state;
+				check_stack(state, 3)?;
+				protect_lua!(state, 0, 0, |state| {
                     if enabled {
                         ffi::luaL_sandbox(state, 1);
                         ffi::luaL_sandboxthread(state);
@@ -882,1854 +903,1852 @@ impl Lua {
                         ffi::luaL_sandbox(state, 0);
                     }
                 })?;
-                extra.sandboxed = enabled;
-            }
-            Ok(())
-        }
-    }
+				extra.sandboxed = enabled;
+			}
+			Ok(())
+		}
+	}
 
-    /// Sets a 'hook' function that will periodically be called as Lua code executes.
-    ///
-    /// When exactly the hook function is called depends on the contents of the `triggers`
-    /// parameter, see [`HookTriggers`] for more details.
-    ///
-    /// The provided hook function can error, and this error will be propagated through the Lua code
-    /// that was executing at the time the hook was triggered. This can be used to implement a
-    /// limited form of execution limits by setting [`HookTriggers.every_nth_instruction`] and
-    /// erroring once an instruction limit has been reached.
-    ///
-    /// # Example
-    ///
-    /// Shows each line number of code being executed by the Lua interpreter.
-    ///
-    /// ```
-    /// # use mlua::{Lua, HookTriggers, Result};
-    /// # fn main() -> Result<()> {
-    /// let lua = Lua::new();
-    /// lua.set_hook(HookTriggers::every_line(), |_lua, debug| {
-    ///     println!("line {}", debug.curr_line());
-    ///     Ok(())
-    /// })?;
-    ///
-    /// lua.load(r#"
-    ///     local x = 2 + 3
-    ///     local y = x * 63
-    ///     local z = string.len(x..", "..y)
-    /// "#).exec()
-    /// # }
-    /// ```
-    ///
-    /// [`HookTriggers`]: crate::HookTriggers
-    /// [`HookTriggers.every_nth_instruction`]: crate::HookTriggers::every_nth_instruction
-    #[cfg(not(feature = "luau"))]
-    #[cfg_attr(docsrs, doc(cfg(not(feature = "luau"))))]
-    pub fn set_hook<F>(&self, triggers: HookTriggers, callback: F) -> Result<()>
-    where
-        F: 'static + MaybeSend + Fn(&Lua, Debug) -> Result<()>,
-    {
-        unsafe extern "C" fn hook_proc(state: *mut ffi::lua_State, ar: *mut ffi::lua_Debug) {
-            let lua = match Lua::make_from_ptr(state) {
-                Some(lua) => lua,
-                None => return,
-            };
-            let extra = lua.extra.get();
-            callback_error_ext(state, extra, move |_| {
-                let debug = Debug::new(&lua, ar);
-                let hook_cb = (*lua.extra.get()).hook_callback.clone();
-                let hook_cb = mlua_expect!(hook_cb, "no hook callback set in hook_proc");
-                if Arc::strong_count(&hook_cb) > 2 {
-                    return Ok(()); // Don't allow recursion
-                }
-                hook_cb(&lua, debug)
-            })
-        }
+	/// Sets a 'hook' function that will periodically be called as Lua code executes.
+	///
+	/// When exactly the hook function is called depends on the contents of the `triggers`
+	/// parameter, see [`HookTriggers`] for more details.
+	///
+	/// The provided hook function can error, and this error will be propagated through the Lua code
+	/// that was executing at the time the hook was triggered. This can be used to implement a
+	/// limited form of execution limits by setting [`HookTriggers.every_nth_instruction`] and
+	/// erroring once an instruction limit has been reached.
+	///
+	/// # Example
+	///
+	/// Shows each line number of code being executed by the Lua interpreter.
+	///
+	/// ```
+	/// # use mlua::{Lua, HookTriggers, Result};
+	/// # fn main() -> Result<()> {
+	/// let lua = Lua::new();
+	/// lua.set_hook(HookTriggers::every_line(), |_lua, debug| {
+	///     println!("line {}", debug.curr_line());
+	///     Ok(())
+	/// })?;
+	///
+	/// lua.load(r#"
+	///     local x = 2 + 3
+	///     local y = x * 63
+	///     local z = string.len(x..", "..y)
+	/// "#).exec()
+	/// # }
+	/// ```
+	///
+	/// [`HookTriggers`]: crate::HookTriggers
+	/// [`HookTriggers.every_nth_instruction`]: crate::HookTriggers::every_nth_instruction
+	#[cfg(not(feature = "luau"))]
+	#[cfg_attr(docsrs, doc(cfg(not(feature = "luau"))))]
+	pub fn set_hook<F>(&self, triggers: HookTriggers, callback: F) -> Result<()>
+		where
+			F: 'static + MaybeSend + Fn(&Lua, Debug) -> Result<()>,
+	{
+		unsafe extern "C" fn hook_proc(state: *mut ffi::lua_State, ar: *mut ffi::lua_Debug) {
+			let lua = match Lua::make_from_ptr(state) {
+				Some(lua) => lua,
+				None => return,
+			};
+			let extra = lua.extra.get();
+			callback_error_ext(state, extra, move |_| {
+				let debug = Debug::new(&lua, ar);
+				let hook_cb = (*lua.extra.get()).hook_callback.clone();
+				let hook_cb = mlua_expect!(hook_cb, "no hook callback set in hook_proc");
+				if Arc::strong_count(&hook_cb) > 2 {
+					return Ok(()); // Don't allow recursion
+				}
+				hook_cb(&lua, debug)
+			})
+		}
 
-        unsafe {
-            let state = get_main_state(self.main_state).ok_or(Error::MainThreadNotAvailable)?;
-            (*self.extra.get()).hook_callback = Some(Arc::new(callback));
-            ffi::lua_sethook(state, Some(hook_proc), triggers.mask(), triggers.count());
-        }
-        Ok(())
-    }
+		unsafe {
+			let state = get_main_state(self.main_state).ok_or(Error::MainThreadNotAvailable)?;
+			(*self.extra.get()).hook_callback = Some(Arc::new(callback));
+			ffi::lua_sethook(state, Some(hook_proc), triggers.mask(), triggers.count());
+		}
+		Ok(())
+	}
 
-    /// Removes any hook previously set by `set_hook`.
-    ///
-    /// This function has no effect if a hook was not previously set.
-    #[cfg(not(feature = "luau"))]
-    #[cfg_attr(docsrs, doc(cfg(not(feature = "luau"))))]
-    pub fn remove_hook(&self) {
-        unsafe {
-            // If main_state is not available, then sethook wasn't called.
-            let state = match get_main_state(self.main_state) {
-                Some(state) => state,
-                None => return,
-            };
-            (*self.extra.get()).hook_callback = None;
-            ffi::lua_sethook(state, None, 0, 0);
-        }
-    }
+	/// Removes any hook previously set by `set_hook`.
+	///
+	/// This function has no effect if a hook was not previously set.
+	#[cfg(not(feature = "luau"))]
+	#[cfg_attr(docsrs, doc(cfg(not(feature = "luau"))))]
+	pub fn remove_hook(&self) {
+		unsafe {
+			// If main_state is not available, then sethook wasn't called.
+			let state = match get_main_state(self.main_state) {
+				Some(state) => state,
+				None => return,
+			};
+			(*self.extra.get()).hook_callback = None;
+			ffi::lua_sethook(state, None, 0, 0);
+		}
+	}
 
-    /// Sets an 'interrupt' function that will periodically be called by Luau VM.
-    ///
-    /// Any Luau code is guaranteed to call this handler "eventually"
-    /// (in practice this can happen at any function call or at any loop iteration).
-    ///
-    /// The provided interrupt function can error, and this error will be propagated through
-    /// the Luau code that was executing at the time the interrupt was triggered.
-    /// Also this can be used to implement continuous execution limits by instructing Luau VM to yield
-    /// by returning [`VmState::Yield`].
-    ///
-    /// This is similar to [`Lua::set_hook`] but in more simplified form.
-    ///
-    /// # Example
-    ///
-    /// Periodically yield Luau VM to suspend execution.
-    ///
-    /// ```
-    /// # use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
-    /// # use mlua::{Lua, Result, ThreadStatus, VmState};
-    /// # fn main() -> Result<()> {
-    /// let lua = Lua::new();
-    /// let count = Arc::new(AtomicU64::new(0));
-    /// lua.set_interrupt(move || {
-    ///     if count.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
-    ///         return Ok(VmState::Yield);
-    ///     }
-    ///     Ok(VmState::Continue)
-    /// });
-    ///
-    /// let co = lua.create_thread(
-    ///     lua.load(r#"
-    ///         local b = 0
-    ///         for _, x in ipairs({1, 2, 3}) do b += x end
-    ///     "#)
-    ///     .into_function()?,
-    /// )?;
-    /// while co.status() == ThreadStatus::Resumable {
-    ///     co.resume(())?;
-    /// }
-    /// # Ok(())
-    /// # }
-    /// ```
-    #[cfg(any(feature = "luau", docsrs))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
-    pub fn set_interrupt<F>(&self, callback: F)
-    where
-        F: 'static + MaybeSend + Fn() -> Result<VmState>,
-    {
-        unsafe extern "C" fn interrupt_proc(state: *mut ffi::lua_State, gc: c_int) {
-            if gc >= 0 {
-                // We don't support GC interrupts since they cannot survive Lua exceptions
-                return;
-            }
-            let extra = match extra_data(state) {
-                Some(e) => e.get(),
-                None => return,
-            };
-            let result = callback_error_ext(state, extra, move |_| {
-                let interrupt_cb = (*extra).interrupt_callback.clone();
-                let interrupt_cb =
-                    mlua_expect!(interrupt_cb, "no interrupt callback set in interrupt_proc");
-                if Arc::strong_count(&interrupt_cb) > 2 {
-                    return Ok(VmState::Continue); // Don't allow recursion
-                }
-                interrupt_cb()
-            });
-            match result {
-                VmState::Continue => {}
-                VmState::Yield => {
-                    ffi::lua_yield(state, 0);
-                }
-            }
-        }
+	/// Sets an 'interrupt' function that will periodically be called by Luau VM.
+	///
+	/// Any Luau code is guaranteed to call this handler "eventually"
+	/// (in practice this can happen at any function call or at any loop iteration).
+	///
+	/// The provided interrupt function can error, and this error will be propagated through
+	/// the Luau code that was executing at the time the interrupt was triggered.
+	/// Also this can be used to implement continuous execution limits by instructing Luau VM to yield
+	/// by returning [`VmState::Yield`].
+	///
+	/// This is similar to [`Lua::set_hook`] but in more simplified form.
+	///
+	/// # Example
+	///
+	/// Periodically yield Luau VM to suspend execution.
+	///
+	/// ```
+	/// # use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
+	/// # use mlua::{Lua, Result, ThreadStatus, VmState};
+	/// # fn main() -> Result<()> {
+	/// let lua = Lua::new();
+	/// let count = Arc::new(AtomicU64::new(0));
+	/// lua.set_interrupt(move || {
+	///     if count.fetch_add(1, Ordering::Relaxed) % 2 == 0 {
+	///         return Ok(VmState::Yield);
+	///     }
+	///     Ok(VmState::Continue)
+	/// });
+	///
+	/// let co = lua.create_thread(
+	///     lua.load(r#"
+	///         local b = 0
+	///         for _, x in ipairs({1, 2, 3}) do b += x end
+	///     "#)
+	///     .into_function()?,
+	/// )?;
+	/// while co.status() == ThreadStatus::Resumable {
+	///     co.resume(())?;
+	/// }
+	/// # Ok(())
+	/// # }
+	/// ```
+	#[cfg(any(feature = "luau", docsrs))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
+	pub fn set_interrupt<F>(&self, callback: F)
+		where
+			F: 'static + MaybeSend + Fn() -> Result<VmState>,
+	{
+		unsafe extern "C" fn interrupt_proc(state: *mut ffi::lua_State, gc: c_int) {
+			if gc >= 0 {
+				// We don't support GC interrupts since they cannot survive Lua exceptions
+				return;
+			}
+			let extra = match extra_data(state) {
+				Some(e) => e.get(),
+				None => return,
+			};
+			let result = callback_error_ext(state, extra, move |_| {
+				let interrupt_cb = (*extra).interrupt_callback.clone();
+				let interrupt_cb =
+					mlua_expect!(interrupt_cb, "no interrupt callback set in interrupt_proc");
+				if Arc::strong_count(&interrupt_cb) > 2 {
+					return Ok(VmState::Continue); // Don't allow recursion
+				}
+				interrupt_cb()
+			});
+			match result {
+				VmState::Continue => {}
+				VmState::Yield => {
+					ffi::lua_yield(state, 0);
+				}
+			}
+		}
 
-        unsafe {
-            (*self.extra.get()).interrupt_callback = Some(Arc::new(callback));
-            (*ffi::lua_callbacks(self.main_state)).interrupt = Some(interrupt_proc);
-        }
-    }
+		unsafe {
+			(*self.extra.get()).interrupt_callback = Some(Arc::new(callback));
+			(*ffi::lua_callbacks(self.main_state)).interrupt = Some(interrupt_proc);
+		}
+	}
 
-    /// Removes any 'interrupt' previously set by `set_interrupt`.
-    ///
-    /// This function has no effect if an 'interrupt' was not previously set.
-    #[cfg(any(feature = "luau", docsrs))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
-    pub fn remove_interrupt(&self) {
-        unsafe {
-            (*self.extra.get()).interrupt_callback = None;
-            (*ffi::lua_callbacks(self.main_state)).interrupt = None;
-        }
-    }
+	/// Removes any 'interrupt' previously set by `set_interrupt`.
+	///
+	/// This function has no effect if an 'interrupt' was not previously set.
+	#[cfg(any(feature = "luau", docsrs))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
+	pub fn remove_interrupt(&self) {
+		unsafe {
+			(*self.extra.get()).interrupt_callback = None;
+			(*ffi::lua_callbacks(self.main_state)).interrupt = None;
+		}
+	}
 
-    /// Sets the warning function to be used by Lua to emit warnings.
-    ///
-    /// Requires `feature = "lua54"`
-    #[cfg(feature = "lua54")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
-    pub fn set_warning_function<F>(&self, callback: F)
-    where
-        F: 'static + MaybeSend + Fn(&Lua, &CStr, bool) -> Result<()>,
-    {
-        unsafe extern "C" fn warn_proc(ud: *mut c_void, msg: *const c_char, tocont: c_int) {
-            let state = ud as *mut ffi::lua_State;
-            let lua = match Lua::make_from_ptr(state) {
-                Some(lua) => lua,
-                None => return,
-            };
-            let extra = lua.extra.get();
-            callback_error_ext(state, extra, move |_| {
-                let cb = mlua_expect!(
+	/// Sets the warning function to be used by Lua to emit warnings.
+	///
+	/// Requires `feature = "lua54"`
+	#[cfg(feature = "lua54")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
+	pub fn set_warning_function<F>(&self, callback: F)
+		where
+			F: 'static + MaybeSend + Fn(&Lua, &CStr, bool) -> Result<()>,
+	{
+		unsafe extern "C" fn warn_proc(ud: *mut c_void, msg: *const c_char, tocont: c_int) {
+			let state = ud as *mut ffi::lua_State;
+			let lua = match Lua::make_from_ptr(state) {
+				Some(lua) => lua,
+				None => return,
+			};
+			let extra = lua.extra.get();
+			callback_error_ext(state, extra, move |_| {
+				let cb = mlua_expect!(
                     (*lua.extra.get()).warn_callback.as_ref(),
                     "no warning callback set in warn_proc"
                 );
-                let msg = CStr::from_ptr(msg);
-                cb(&lua, msg, tocont != 0)
-            });
-        }
+				let msg = CStr::from_ptr(msg);
+				cb(&lua, msg, tocont != 0)
+			});
+		}
 
-        let state = self.main_state;
-        unsafe {
-            (*self.extra.get()).warn_callback = Some(Box::new(callback));
-            ffi::lua_setwarnf(state, Some(warn_proc), state as *mut c_void);
-        }
-    }
+		let state = self.main_state;
+		unsafe {
+			(*self.extra.get()).warn_callback = Some(Box::new(callback));
+			ffi::lua_setwarnf(state, Some(warn_proc), state as *mut c_void);
+		}
+	}
 
-    /// Removes warning function previously set by `set_warning_function`.
-    ///
-    /// This function has no effect if a warning function was not previously set.
-    ///
-    /// Requires `feature = "lua54"`
-    #[cfg(feature = "lua54")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
-    pub fn remove_warning_function(&self) {
-        unsafe {
-            (*self.extra.get()).warn_callback = None;
-            ffi::lua_setwarnf(self.main_state, None, ptr::null_mut());
-        }
-    }
+	/// Removes warning function previously set by `set_warning_function`.
+	///
+	/// This function has no effect if a warning function was not previously set.
+	///
+	/// Requires `feature = "lua54"`
+	#[cfg(feature = "lua54")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
+	pub fn remove_warning_function(&self) {
+		unsafe {
+			(*self.extra.get()).warn_callback = None;
+			ffi::lua_setwarnf(self.main_state, None, ptr::null_mut());
+		}
+	}
 
-    /// Emits a warning with the given message.
-    ///
-    /// A message in a call with `tocont` set to `true` should be continued in another call to this function.
-    ///
-    /// Requires `feature = "lua54"`
-    #[cfg(feature = "lua54")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
-    pub fn warning<S: Into<Vec<u8>>>(&self, msg: S, tocont: bool) -> Result<()> {
-        let msg = CString::new(msg).map_err(|err| Error::RuntimeError(err.to_string()))?;
-        unsafe { ffi::lua_warning(self.state, msg.as_ptr(), if tocont { 1 } else { 0 }) };
-        Ok(())
-    }
+	/// Emits a warning with the given message.
+	///
+	/// A message in a call with `tocont` set to `true` should be continued in another call to this function.
+	///
+	/// Requires `feature = "lua54"`
+	#[cfg(feature = "lua54")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
+	pub fn warning<S: Into<Vec<u8>>>(&self, msg: S, tocont: bool) -> Result<()> {
+		let msg = CString::new(msg).map_err(|err| Error::RuntimeError(err.to_string()))?;
+		unsafe { ffi::lua_warning(self.state, msg.as_ptr(), if tocont { 1 } else { 0 }) };
+		Ok(())
+	}
 
-    /// Gets information about the interpreter runtime stack.
-    ///
-    /// This function returns [`Debug`] structure that can be used to get information about the function
-    /// executing at a given level. Level `0` is the current running function, whereas level `n+1` is the
-    /// function that has called level `n` (except for tail calls, which do not count in the stack).
-    ///
-    /// [`Debug`]: crate::hook::Debug
-    pub fn inspect_stack(&self, level: usize) -> Option<Debug> {
-        unsafe {
-            let mut ar: ffi::lua_Debug = mem::zeroed();
-            let level = level as c_int;
-            #[cfg(not(feature = "luau"))]
-            if ffi::lua_getstack(self.state, level, &mut ar) == 0 {
-                return None;
-            }
-            #[cfg(feature = "luau")]
-            if ffi::lua_getinfo(self.state, level, cstr!(""), &mut ar) == 0 {
-                return None;
-            }
-            Some(Debug::new_owned(self, level, ar))
-        }
-    }
+	/// Gets information about the interpreter runtime stack.
+	///
+	/// This function returns [`Debug`] structure that can be used to get information about the function
+	/// executing at a given level. Level `0` is the current running function, whereas level `n+1` is the
+	/// function that has called level `n` (except for tail calls, which do not count in the stack).
+	///
+	/// [`Debug`]: crate::hook::Debug
+	pub fn inspect_stack(&self, level: usize) -> Option<Debug> {
+		unsafe {
+			let mut ar: ffi::lua_Debug = mem::zeroed();
+			let level = level as c_int;
+			#[cfg(not(feature = "luau"))]
+			if ffi::lua_getstack(self.state, level, &mut ar) == 0 {
+				return None;
+			}
+			#[cfg(feature = "luau")]
+			if ffi::lua_getinfo(self.state, level, cstr!(""), &mut ar) == 0 {
+				return None;
+			}
+			Some(Debug::new_owned(self, level, ar))
+		}
+	}
 
-    /// Returns the amount of memory (in bytes) currently used inside this Lua state.
-    pub fn used_memory(&self) -> usize {
-        unsafe {
-            match (*self.extra.get()).mem_info.map(|x| x.as_ref()) {
-                Some(mem_info) => mem_info.used_memory as usize,
-                None => {
-                    // Get data from the Lua GC
-                    let used_kbytes = ffi::lua_gc(self.main_state, ffi::LUA_GCCOUNT, 0);
-                    let used_kbytes_rem = ffi::lua_gc(self.main_state, ffi::LUA_GCCOUNTB, 0);
-                    (used_kbytes as usize) * 1024 + (used_kbytes_rem as usize)
-                }
-            }
-        }
-    }
+	/// Returns the amount of memory (in bytes) currently used inside this Lua state.
+	pub fn used_memory(&self) -> usize {
+		unsafe {
+			match (*self.extra.get()).mem_info.map(|x| x.as_ref()) {
+				Some(mem_info) => mem_info.used_memory as usize,
+				None => {
+					// Get data from the Lua GC
+					let used_kbytes = ffi::lua_gc(self.main_state, ffi::LUA_GCCOUNT, 0);
+					let used_kbytes_rem = ffi::lua_gc(self.main_state, ffi::LUA_GCCOUNTB, 0);
+					(used_kbytes as usize) * 1024 + (used_kbytes_rem as usize)
+				}
+			}
+		}
+	}
 
-    /// Sets a memory limit (in bytes) on this Lua state.
-    ///
-    /// Once an allocation occurs that would pass this memory limit,
-    /// a `Error::MemoryError` is generated instead.
-    /// Returns previous limit (zero means no limit).
-    ///
-    /// Does not work on module mode where Lua state is managed externally.
-    ///
-    /// Requires `feature = "lua54/lua53/lua52"`
-    #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
-    pub fn set_memory_limit(&self, memory_limit: usize) -> Result<usize> {
-        unsafe {
-            match (*self.extra.get()).mem_info.map(|mut x| x.as_mut()) {
-                Some(mem_info) => {
-                    let prev_limit = mem_info.memory_limit as usize;
-                    mem_info.memory_limit = memory_limit as isize;
-                    Ok(prev_limit)
-                }
-                None => Err(Error::MemoryLimitNotAvailable),
-            }
-        }
-    }
+	/// Sets a memory limit (in bytes) on this Lua state.
+	///
+	/// Once an allocation occurs that would pass this memory limit,
+	/// a `Error::MemoryError` is generated instead.
+	/// Returns previous limit (zero means no limit).
+	///
+	/// Does not work on module mode where Lua state is managed externally.
+	///
+	/// Requires `feature = "lua54/lua53/lua52"`
+	#[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
+	pub fn set_memory_limit(&self, memory_limit: usize) -> Result<usize> {
+		unsafe {
+			match (*self.extra.get()).mem_info.map(|mut x| x.as_mut()) {
+				Some(mem_info) => {
+					let prev_limit = mem_info.memory_limit as usize;
+					mem_info.memory_limit = memory_limit as isize;
+					Ok(prev_limit)
+				}
+				None => Err(Error::MemoryLimitNotAvailable),
+			}
+		}
+	}
 
-    /// Returns true if the garbage collector is currently running automatically.
-    ///
-    /// Requires `feature = "lua54/lua53/lua52/luau"`
-    #[cfg(any(
-        feature = "lua54",
-        feature = "lua53",
-        feature = "lua52",
-        feature = "luau"
-    ))]
-    pub fn gc_is_running(&self) -> bool {
-        unsafe { ffi::lua_gc(self.main_state, ffi::LUA_GCISRUNNING, 0) != 0 }
-    }
+	/// Returns true if the garbage collector is currently running automatically.
+	///
+	/// Requires `feature = "lua54/lua53/lua52/luau"`
+	#[cfg(any(
+	feature = "lua54",
+	feature = "lua53",
+	feature = "lua52",
+	feature = "luau"
+	))]
+	pub fn gc_is_running(&self) -> bool {
+		unsafe { ffi::lua_gc(self.main_state, ffi::LUA_GCISRUNNING, 0) != 0 }
+	}
 
-    /// Stop the Lua GC from running
-    pub fn gc_stop(&self) {
-        unsafe { ffi::lua_gc(self.main_state, ffi::LUA_GCSTOP, 0) };
-    }
+	/// Stop the Lua GC from running
+	pub fn gc_stop(&self) {
+		unsafe { ffi::lua_gc(self.main_state, ffi::LUA_GCSTOP, 0) };
+	}
 
-    /// Restarts the Lua GC if it is not running
-    pub fn gc_restart(&self) {
-        unsafe { ffi::lua_gc(self.main_state, ffi::LUA_GCRESTART, 0) };
-    }
+	/// Restarts the Lua GC if it is not running
+	pub fn gc_restart(&self) {
+		unsafe { ffi::lua_gc(self.main_state, ffi::LUA_GCRESTART, 0) };
+	}
 
-    /// Perform a full garbage-collection cycle.
-    ///
-    /// It may be necessary to call this function twice to collect all currently unreachable
-    /// objects. Once to finish the current gc cycle, and once to start and finish the next cycle.
-    pub fn gc_collect(&self) -> Result<()> {
-        unsafe {
-            check_stack(self.main_state, 2)?;
-            protect_lua!(self.main_state, 0, 0, fn(state) ffi::lua_gc(state, ffi::LUA_GCCOLLECT, 0))
-        }
-    }
+	/// Perform a full garbage-collection cycle.
+	///
+	/// It may be necessary to call this function twice to collect all currently unreachable
+	/// objects. Once to finish the current gc cycle, and once to start and finish the next cycle.
+	pub fn gc_collect(&self) -> Result<()> {
+		unsafe {
+			check_stack(self.main_state, 2)?;
+			protect_lua!(self.main_state, 0, 0, fn(state) ffi::lua_gc(state, ffi::LUA_GCCOLLECT, 0))
+		}
+	}
 
-    /// Steps the garbage collector one indivisible step.
-    ///
-    /// Returns true if this has finished a collection cycle.
-    pub fn gc_step(&self) -> Result<bool> {
-        self.gc_step_kbytes(0)
-    }
+	/// Steps the garbage collector one indivisible step.
+	///
+	/// Returns true if this has finished a collection cycle.
+	pub fn gc_step(&self) -> Result<bool> {
+		self.gc_step_kbytes(0)
+	}
 
-    /// Steps the garbage collector as though memory had been allocated.
-    ///
-    /// if `kbytes` is 0, then this is the same as calling `gc_step`. Returns true if this step has
-    /// finished a collection cycle.
-    pub fn gc_step_kbytes(&self, kbytes: c_int) -> Result<bool> {
-        unsafe {
-            check_stack(self.main_state, 3)?;
-            protect_lua!(self.main_state, 0, 0, |state| {
+	/// Steps the garbage collector as though memory had been allocated.
+	///
+	/// if `kbytes` is 0, then this is the same as calling `gc_step`. Returns true if this step has
+	/// finished a collection cycle.
+	pub fn gc_step_kbytes(&self, kbytes: c_int) -> Result<bool> {
+		unsafe {
+			check_stack(self.main_state, 3)?;
+			protect_lua!(self.main_state, 0, 0, |state| {
                 ffi::lua_gc(state, ffi::LUA_GCSTEP, kbytes) != 0
             })
-        }
-    }
+		}
+	}
 
-    /// Sets the 'pause' value of the collector.
-    ///
-    /// Returns the previous value of 'pause'. More information can be found in the Lua
-    /// [documentation].
-    ///
-    /// For Luau this parameter sets GC goal
-    ///
-    /// [documentation]: https://www.lua.org/manual/5.4/manual.html#2.5
-    pub fn gc_set_pause(&self, pause: c_int) -> c_int {
-        unsafe {
-            #[cfg(not(feature = "luau"))]
-            return ffi::lua_gc(self.main_state, ffi::LUA_GCSETPAUSE, pause);
-            #[cfg(feature = "luau")]
-            return ffi::lua_gc(self.main_state, ffi::LUA_GCSETGOAL, pause);
-        }
-    }
+	/// Sets the 'pause' value of the collector.
+	///
+	/// Returns the previous value of 'pause'. More information can be found in the Lua
+	/// [documentation].
+	///
+	/// For Luau this parameter sets GC goal
+	///
+	/// [documentation]: https://www.lua.org/manual/5.4/manual.html#2.5
+	pub fn gc_set_pause(&self, pause: c_int) -> c_int {
+		unsafe {
+			#[cfg(not(feature = "luau"))]
+			return ffi::lua_gc(self.main_state, ffi::LUA_GCSETPAUSE, pause);
+			#[cfg(feature = "luau")]
+			return ffi::lua_gc(self.main_state, ffi::LUA_GCSETGOAL, pause);
+		}
+	}
 
-    /// Sets the 'step multiplier' value of the collector.
-    ///
-    /// Returns the previous value of the 'step multiplier'. More information can be found in the
-    /// Lua [documentation].
-    ///
-    /// [documentation]: https://www.lua.org/manual/5.4/manual.html#2.5
-    pub fn gc_set_step_multiplier(&self, step_multiplier: c_int) -> c_int {
-        unsafe { ffi::lua_gc(self.main_state, ffi::LUA_GCSETSTEPMUL, step_multiplier) }
-    }
+	/// Sets the 'step multiplier' value of the collector.
+	///
+	/// Returns the previous value of the 'step multiplier'. More information can be found in the
+	/// Lua [documentation].
+	///
+	/// [documentation]: https://www.lua.org/manual/5.4/manual.html#2.5
+	pub fn gc_set_step_multiplier(&self, step_multiplier: c_int) -> c_int {
+		unsafe { ffi::lua_gc(self.main_state, ffi::LUA_GCSETSTEPMUL, step_multiplier) }
+	}
 
-    /// Changes the collector to incremental mode with the given parameters.
-    ///
-    /// Returns the previous mode (always `GCMode::Incremental` in Lua < 5.4).
-    /// More information can be found in the Lua [documentation].
-    ///
-    /// [documentation]: https://www.lua.org/manual/5.4/manual.html#2.5.1
-    pub fn gc_inc(&self, pause: c_int, step_multiplier: c_int, step_size: c_int) -> GCMode {
-        let state = self.main_state;
+	/// Changes the collector to incremental mode with the given parameters.
+	///
+	/// Returns the previous mode (always `GCMode::Incremental` in Lua < 5.4).
+	/// More information can be found in the Lua [documentation].
+	///
+	/// [documentation]: https://www.lua.org/manual/5.4/manual.html#2.5.1
+	pub fn gc_inc(&self, pause: c_int, step_multiplier: c_int, step_size: c_int) -> GCMode {
+		let state = self.main_state;
 
-        #[cfg(any(
-            feature = "lua53",
-            feature = "lua52",
-            feature = "lua51",
-            feature = "luajit",
-            feature = "luau"
-        ))]
-        unsafe {
-            if pause > 0 {
-                #[cfg(not(feature = "luau"))]
-                ffi::lua_gc(state, ffi::LUA_GCSETPAUSE, pause);
-                #[cfg(feature = "luau")]
-                ffi::lua_gc(state, ffi::LUA_GCSETGOAL, pause);
-            }
+		#[cfg(any(
+		feature = "lua53",
+		feature = "lua52",
+		feature = "lua51",
+		feature = "luajit",
+		feature = "luau"
+		))]
+		unsafe {
+			if pause > 0 {
+				#[cfg(not(feature = "luau"))]
+				ffi::lua_gc(state, ffi::LUA_GCSETPAUSE, pause);
+				#[cfg(feature = "luau")]
+				ffi::lua_gc(state, ffi::LUA_GCSETGOAL, pause);
+			}
 
-            if step_multiplier > 0 {
-                ffi::lua_gc(state, ffi::LUA_GCSETSTEPMUL, step_multiplier);
-            }
+			if step_multiplier > 0 {
+				ffi::lua_gc(state, ffi::LUA_GCSETSTEPMUL, step_multiplier);
+			}
 
-            #[cfg(feature = "luau")]
-            if step_size > 0 {
-                ffi::lua_gc(state, ffi::LUA_GCSETSTEPSIZE, step_size);
-            }
-            #[cfg(not(feature = "luau"))]
-            let _ = step_size; // Ignored
+			#[cfg(feature = "luau")]
+			if step_size > 0 {
+				ffi::lua_gc(state, ffi::LUA_GCSETSTEPSIZE, step_size);
+			}
+			#[cfg(not(feature = "luau"))]
+				let _ = step_size; // Ignored
 
-            GCMode::Incremental
-        }
+			GCMode::Incremental
+		}
 
-        #[cfg(feature = "lua54")]
-        let prev_mode =
-            unsafe { ffi::lua_gc(state, ffi::LUA_GCINC, pause, step_multiplier, step_size) };
-        #[cfg(feature = "lua54")]
-        match prev_mode {
-            ffi::LUA_GCINC => GCMode::Incremental,
-            ffi::LUA_GCGEN => GCMode::Generational,
-            _ => unreachable!(),
-        }
-    }
+		#[cfg(feature = "lua54")]
+			let prev_mode =
+			unsafe { ffi::lua_gc(state, ffi::LUA_GCINC, pause, step_multiplier, step_size) };
+		#[cfg(feature = "lua54")]
+		match prev_mode {
+			ffi::LUA_GCINC => GCMode::Incremental,
+			ffi::LUA_GCGEN => GCMode::Generational,
+			_ => unreachable!(),
+		}
+	}
 
-    /// Changes the collector to generational mode with the given parameters.
-    ///
-    /// Returns the previous mode. More information about the generational GC
-    /// can be found in the Lua 5.4 [documentation][lua_doc].
-    ///
-    /// Requires `feature = "lua54"`
-    ///
-    /// [lua_doc]: https://www.lua.org/manual/5.4/manual.html#2.5.2
-    #[cfg(any(feature = "lua54"))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
-    pub fn gc_gen(&self, minor_multiplier: c_int, major_multiplier: c_int) -> GCMode {
-        let state = self.main_state;
-        let prev_mode =
-            unsafe { ffi::lua_gc(state, ffi::LUA_GCGEN, minor_multiplier, major_multiplier) };
-        match prev_mode {
-            ffi::LUA_GCGEN => GCMode::Generational,
-            ffi::LUA_GCINC => GCMode::Incremental,
-            _ => unreachable!(),
-        }
-    }
+	/// Changes the collector to generational mode with the given parameters.
+	///
+	/// Returns the previous mode. More information about the generational GC
+	/// can be found in the Lua 5.4 [documentation][lua_doc].
+	///
+	/// Requires `feature = "lua54"`
+	///
+	/// [lua_doc]: https://www.lua.org/manual/5.4/manual.html#2.5.2
+	#[cfg(any(feature = "lua54"))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "lua54")))]
+	pub fn gc_gen(&self, minor_multiplier: c_int, major_multiplier: c_int) -> GCMode {
+		let state = self.main_state;
+		let prev_mode =
+			unsafe { ffi::lua_gc(state, ffi::LUA_GCGEN, minor_multiplier, major_multiplier) };
+		match prev_mode {
+			ffi::LUA_GCGEN => GCMode::Generational,
+			ffi::LUA_GCINC => GCMode::Incremental,
+			_ => unreachable!(),
+		}
+	}
 
-    /// Sets a default Luau compiler (with custom options).
-    ///
-    /// This compiler will be used by default to load all Lua chunks
-    /// including via `require` function.
-    ///
-    /// See [`Compiler`] for details and possible options.
-    ///
-    /// Requires `feature = "luau"`
-    #[cfg(any(feature = "luau", doc))]
-    #[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
-    pub fn set_compiler(&self, compiler: Compiler) {
-        unsafe { (*self.0.get()).compiler = Some(compiler) };
-    }
+	/// Sets a default Luau compiler (with custom options).
+	///
+	/// This compiler will be used by default to load all Lua chunks
+	/// including via `require` function.
+	///
+	/// See [`Compiler`] for details and possible options.
+	///
+	/// Requires `feature = "luau"`
+	#[cfg(any(feature = "luau", doc))]
+	#[cfg_attr(docsrs, doc(cfg(feature = "luau")))]
+	pub fn set_compiler(&self, compiler: Compiler) {
+		unsafe { (*self.0.get()).compiler = Some(compiler) };
+	}
 
-    /// Returns Lua source code as a `Chunk` builder type.
-    ///
-    /// In order to actually compile or run the resulting code, you must call [`Chunk::exec`] or
-    /// similar on the returned builder. Code is not even parsed until one of these methods is
-    /// called.
-    ///
-    /// [`Chunk::exec`]: crate::Chunk::exec
-    #[track_caller]
-    pub fn load<'lua, 'a, S>(&'lua self, chunk: &'a S) -> Chunk<'lua, 'a>
-    where
-        S: AsChunk<'lua> + ?Sized,
-    {
-        let name = chunk
-            .name()
-            .unwrap_or_else(|| Location::caller().to_string());
+	/// Returns Lua source code as a `Chunk` builder type.
+	///
+	/// In order to actually compile or run the resulting code, you must call [`Chunk::exec`] or
+	/// similar on the returned builder. Code is not even parsed until one of these methods is
+	/// called.
+	///
+	/// [`Chunk::exec`]: crate::Chunk::exec
+	#[track_caller]
+	pub fn load<'a, S>(&self, chunk: &'a S) -> Chunk<'a>
+		where
+			S: AsChunk + ?Sized,
+	{
+		let name = chunk
+			.name()
+			.unwrap_or_else(|| Location::caller().to_string());
 
-        Chunk {
-            lua: self,
-            source: chunk.source(),
-            name: Some(name),
-            env: chunk.env(self),
-            mode: chunk.mode(),
-            #[cfg(feature = "luau")]
-            compiler: self.compiler.clone(),
-        }
-    }
+		Chunk {
+			lua: LuaWeakRef::new(self),
+			source: chunk.source(),
+			name: Some(name),
+			env: chunk.env(self),
+			mode: chunk.mode(),
+			#[cfg(feature = "luau")]
+			compiler: self.compiler.clone(),
+		}
+	}
 
-    pub(crate) fn load_chunk<'lua>(
-        &'lua self,
-        source: &[u8],
-        name: Option<&CStr>,
-        env: Option<Value<'lua>>,
-        mode: Option<ChunkMode>,
-    ) -> Result<Function<'lua>> {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 1)?;
+	pub(crate) fn load_chunk(
+		&self,
+		source: &[u8],
+		name: Option<&CStr>,
+		env: Option<Value>,
+		mode: Option<ChunkMode>,
+	) -> Result<Function> {
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 1)?;
 
-            let mode_str = match mode {
-                Some(ChunkMode::Binary) => cstr!("b"),
-                Some(ChunkMode::Text) => cstr!("t"),
-                None => cstr!("bt"),
-            };
+			let mode_str = match mode {
+				Some(ChunkMode::Binary) => cstr!("b"),
+				Some(ChunkMode::Text) => cstr!("t"),
+				None => cstr!("bt"),
+			};
 
-            match ffi::luaL_loadbufferx(
-                self.state,
-                source.as_ptr() as *const c_char,
-                source.len(),
-                name.map(|n| n.as_ptr()).unwrap_or_else(ptr::null),
-                mode_str,
-            ) {
-                ffi::LUA_OK => {
-                    if let Some(env) = env {
-                        self.push_value(env)?;
-                        #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
-                        ffi::lua_setupvalue(self.state, -2, 1);
-                        #[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
-                        ffi::lua_setfenv(self.state, -2);
-                    }
-                    Ok(Function(self.pop_ref()))
-                }
-                err => Err(pop_error(self.state, err)),
-            }
-        }
-    }
+			match ffi::luaL_loadbufferx(
+				self.state,
+				source.as_ptr() as *const c_char,
+				source.len(),
+				name.map(|n| n.as_ptr()).unwrap_or_else(ptr::null),
+				mode_str,
+			) {
+				ffi::LUA_OK => {
+					if let Some(env) = env {
+						self.push_value(env)?;
+						#[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
+						ffi::lua_setupvalue(self.state, -2, 1);
+						#[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
+						ffi::lua_setfenv(self.state, -2);
+					}
+					Ok(Function(self.pop_ref()))
+				}
+				err => Err(pop_error(self.state, err)),
+			}
+		}
+	}
 
-    /// Create and return an interned Lua string. Lua strings can be arbitrary [u8] data including
-    /// embedded nulls, so in addition to `&str` and `&String`, you can also pass plain `&[u8]`
-    /// here.
-    pub fn create_string<S>(&self, s: &S) -> Result<String>
-    where
-        S: AsRef<[u8]> + ?Sized,
-    {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 3)?;
-            push_string(self.state, s)?;
-            Ok(String(self.pop_ref()))
-        }
-    }
+	/// Create and return an interned Lua string. Lua strings can be arbitrary [u8] data including
+	/// embedded nulls, so in addition to `&str` and `&String`, you can also pass plain `&[u8]`
+	/// here.
+	pub fn create_string<S>(&self, s: &S) -> Result<String>
+		where
+			S: AsRef<[u8]> + ?Sized,
+	{
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 3)?;
+			push_string(self.state, s)?;
+			Ok(String(self.pop_ref()))
+		}
+	}
 
-    /// Creates and returns a new empty table.
-    pub fn create_table(&self) -> Result<Table> {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 2)?;
-            protect_lua!(self.state, 0, 1, fn(state) ffi::lua_newtable(state))?;
-            Ok(Table(self.pop_ref()))
-        }
-    }
+	/// Creates and returns a new empty table.
+	pub fn create_table(&self) -> Result<Table> {
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 2)?;
+			protect_lua!(self.state, 0, 1, fn(state) ffi::lua_newtable(state))?;
+			Ok(Table(self.pop_ref()))
+		}
+	}
 
-    /// Creates and returns a new empty table, with the specified capacity.
-    /// `narr` is a hint for how many elements the table will have as a sequence;
-    /// `nrec` is a hint for how many other elements the table will have.
-    /// Lua may use these hints to preallocate memory for the new table.
-    pub fn create_table_with_capacity(&self, narr: c_int, nrec: c_int) -> Result<Table> {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 3)?;
-            push_table(self.state, narr, nrec)?;
-            Ok(Table(self.pop_ref()))
-        }
-    }
+	/// Creates and returns a new empty table, with the specified capacity.
+	/// `narr` is a hint for how many elements the table will have as a sequence;
+	/// `nrec` is a hint for how many other elements the table will have.
+	/// Lua may use these hints to preallocate memory for the new table.
+	pub fn create_table_with_capacity(&self, narr: c_int, nrec: c_int) -> Result<Table> {
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 3)?;
+			push_table(self.state, narr, nrec)?;
+			Ok(Table(self.pop_ref()))
+		}
+	}
 
-    /// Creates a table and fills it with values from an iterator.
-    pub fn create_table_from<'lua, K, V, I>(&'lua self, iter: I) -> Result<Table<'lua>>
-    where
-        K: ToLua<'lua>,
-        V: ToLua<'lua>,
-        I: IntoIterator<Item = (K, V)>,
-    {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 6)?;
+	/// Creates a table and fills it with values from an iterator.
+	pub fn create_table_from<'lua, K, V, I>(&'lua self, iter: I) -> Result<Table>
+		where
+			K: ToLua,
+			V: ToLua,
+			I: IntoIterator<Item=(K, V)>,
+	{
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 6)?;
 
-            let iter = iter.into_iter();
-            let lower_bound = iter.size_hint().0;
-            push_table(self.state, 0, lower_bound as c_int)?;
-            for (k, v) in iter {
-                self.push_value(k.to_lua(self)?)?;
-                self.push_value(v.to_lua(self)?)?;
-                protect_lua!(self.state, 3, 1, fn(state) ffi::lua_rawset(state, -3))?;
-            }
+			let iter = iter.into_iter();
+			let lower_bound = iter.size_hint().0;
+			push_table(self.state, 0, lower_bound as c_int)?;
+			for (k, v) in iter {
+				self.push_value(k.to_lua(self)?)?;
+				self.push_value(v.to_lua(self)?)?;
+				protect_lua!(self.state, 3, 1, fn(state) ffi::lua_rawset(state, -3))?;
+			}
 
-            Ok(Table(self.pop_ref()))
-        }
-    }
+			Ok(Table(self.pop_ref()))
+		}
+	}
 
-    /// Creates a table from an iterator of values, using `1..` as the keys.
-    pub fn create_sequence_from<'lua, T, I>(&'lua self, iter: I) -> Result<Table<'lua>>
-    where
-        T: ToLua<'lua>,
-        I: IntoIterator<Item = T>,
-    {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 5)?;
+	/// Creates a table from an iterator of values, using `1..` as the keys.
+	pub fn create_sequence_from<'lua, T, I>(&'lua self, iter: I) -> Result<Table>
+		where
+			T: ToLua,
+			I: IntoIterator<Item=T>,
+	{
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 5)?;
 
-            let iter = iter.into_iter();
-            let lower_bound = iter.size_hint().0;
-            push_table(self.state, lower_bound as c_int, 0)?;
-            for (i, v) in iter.enumerate() {
-                self.push_value(v.to_lua(self)?)?;
-                protect_lua!(self.state, 2, 1, |state| {
+			let iter = iter.into_iter();
+			let lower_bound = iter.size_hint().0;
+			push_table(self.state, lower_bound as c_int, 0)?;
+			for (i, v) in iter.enumerate() {
+				self.push_value(v.to_lua(self)?)?;
+				protect_lua!(self.state, 2, 1, |state| {
                     ffi::lua_rawseti(state, -2, (i + 1) as Integer);
                 })?;
-            }
+			}
 
-            Ok(Table(self.pop_ref()))
-        }
-    }
+			Ok(Table(self.pop_ref()))
+		}
+	}
 
-    /// Wraps a Rust function or closure, creating a callable Lua function handle to it.
-    ///
-    /// The function's return value is always a `Result`: If the function returns `Err`, the error
-    /// is raised as a Lua error, which can be caught using `(x)pcall` or bubble up to the Rust code
-    /// that invoked the Lua code. This allows using the `?` operator to propagate errors through
-    /// intermediate Lua code.
-    ///
-    /// If the function returns `Ok`, the contained value will be converted to one or more Lua
-    /// values. For details on Rust-to-Lua conversions, refer to the [`ToLua`] and [`ToLuaMulti`]
-    /// traits.
-    ///
-    /// # Examples
-    ///
-    /// Create a function which prints its argument:
-    ///
-    /// ```
-    /// # use mlua::{Lua, Result};
-    /// # fn main() -> Result<()> {
-    /// # let lua = Lua::new();
-    /// let greet = lua.create_function(|_, name: String| {
-    ///     println!("Hello, {}!", name);
-    ///     Ok(())
-    /// });
-    /// # let _ = greet;    // used
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// Use tuples to accept multiple arguments:
-    ///
-    /// ```
-    /// # use mlua::{Lua, Result};
-    /// # fn main() -> Result<()> {
-    /// # let lua = Lua::new();
-    /// let print_person = lua.create_function(|_, (name, age): (String, u8)| {
-    ///     println!("{} is {} years old!", name, age);
-    ///     Ok(())
-    /// });
-    /// # let _ = print_person;    // used
-    /// # Ok(())
-    /// # }
-    /// ```
-    ///
-    /// [`ToLua`]: crate::ToLua
-    /// [`ToLuaMulti`]: crate::ToLuaMulti
-    pub fn create_function<'lua, A, R, F>(&'lua self, func: F) -> Result<Function<'lua>>
-    where
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> Result<R>,
-    {
-        self.create_callback(Box::new(move |lua, args| {
-            func(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-        }))
-    }
+	/// Wraps a Rust function or closure, creating a callable Lua function handle to it.
+	///
+	/// The function's return value is always a `Result`: If the function returns `Err`, the error
+	/// is raised as a Lua error, which can be caught using `(x)pcall` or bubble up to the Rust code
+	/// that invoked the Lua code. This allows using the `?` operator to propagate errors through
+	/// intermediate Lua code.
+	///
+	/// If the function returns `Ok`, the contained value will be converted to one or more Lua
+	/// values. For details on Rust-to-Lua conversions, refer to the [`ToLua`] and [`ToLuaMulti`]
+	/// traits.
+	///
+	/// # Examples
+	///
+	/// Create a function which prints its argument:
+	///
+	/// ```
+	/// # use mlua::{Lua, Result};
+	/// # fn main() -> Result<()> {
+	/// # let lua = Lua::new();
+	/// let greet = lua.create_function(|_, name: String| {
+	///     println!("Hello, {}!", name);
+	///     Ok(())
+	/// });
+	/// # let _ = greet;    // used
+	/// # Ok(())
+	/// # }
+	/// ```
+	///
+	/// Use tuples to accept multiple arguments:
+	///
+	/// ```
+	/// # use mlua::{Lua, Result};
+	/// # fn main() -> Result<()> {
+	/// # let lua = Lua::new();
+	/// let print_person = lua.create_function(|_, (name, age): (String, u8)| {
+	///     println!("{} is {} years old!", name, age);
+	///     Ok(())
+	/// });
+	/// # let _ = print_person;    // used
+	/// # Ok(())
+	/// # }
+	/// ```
+	///
+	/// [`ToLua`]: crate::ToLua
+	/// [`ToLuaMulti`]: crate::ToLuaMulti
+	pub fn create_function<'lua, A, R, F>(&'lua self, func: F) -> Result<Function>
+		where
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + Fn(&Lua, A) -> Result<R>,
+	{
+		self.create_callback(Box::new(move |lua, args| {
+			func(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+		}))
+	}
 
-    /// Wraps a Rust mutable closure, creating a callable Lua function handle to it.
-    ///
-    /// This is a version of [`create_function`] that accepts a FnMut argument. Refer to
-    /// [`create_function`] for more information about the implementation.
-    ///
-    /// [`create_function`]: #method.create_function
-    pub fn create_function_mut<'lua, A, R, F>(&'lua self, func: F) -> Result<Function<'lua>>
-    where
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + FnMut(&'lua Lua, A) -> Result<R>,
-    {
-        let func = RefCell::new(func);
-        self.create_function(move |lua, args| {
-            (*func
-                .try_borrow_mut()
-                .map_err(|_| Error::RecursiveMutCallback)?)(lua, args)
-        })
-    }
+	/// Wraps a Rust mutable closure, creating a callable Lua function handle to it.
+	///
+	/// This is a version of [`create_function`] that accepts a FnMut argument. Refer to
+	/// [`create_function`] for more information about the implementation.
+	///
+	/// [`create_function`]: #method.create_function
+	pub fn create_function_mut<'lua, A, R, F>(&'lua self, func: F) -> Result<Function>
+		where
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + FnMut(&Lua, A) -> Result<R>,
+	{
+		let func = RefCell::new(func);
+		self.create_function(move |lua, args| {
+			(*func
+				.try_borrow_mut()
+				.map_err(|_| Error::RecursiveMutCallback)?)(lua, args)
+		})
+	}
 
-    /// Wraps a C function, creating a callable Lua function handle to it.
-    ///
-    /// # Safety
-    /// This function is unsafe because provides a way to execute unsafe C function.
-    pub unsafe fn create_c_function(&self, func: ffi::lua_CFunction) -> Result<Function> {
-        check_stack(self.state, 1)?;
-        ffi::lua_pushcfunction(self.state, func);
-        Ok(Function(self.pop_ref()))
-    }
+	/// Wraps a C function, creating a callable Lua function handle to it.
+	///
+	/// # Safety
+	/// This function is unsafe because provides a way to execute unsafe C function.
+	pub unsafe fn create_c_function(&self, func: ffi::lua_CFunction) -> Result<Function> {
+		check_stack(self.state, 1)?;
+		ffi::lua_pushcfunction(self.state, func);
+		Ok(Function(self.pop_ref()))
+	}
 
-    /// Wraps a Rust async function or closure, creating a callable Lua function handle to it.
-    ///
-    /// While executing the function Rust will poll Future and if the result is not ready, call
-    /// `yield()` passing internal representation of a `Poll::Pending` value.
-    ///
-    /// The function must be called inside Lua coroutine ([`Thread`]) to be able to suspend its execution.
-    /// An executor should be used to poll [`AsyncThread`] and mlua will take a provided Waker
-    /// in that case. Otherwise noop waker will be used if try to call the function outside of Rust
-    /// executors.
-    ///
-    /// The family of `call_async()` functions takes care about creating [`Thread`].
-    ///
-    /// Requires `feature = "async"`
-    ///
-    /// # Examples
-    ///
-    /// Non blocking sleep:
-    ///
-    /// ```
-    /// use std::time::Duration;
-    /// use futures_timer::Delay;
-    /// use mlua::{Lua, Result};
-    ///
-    /// async fn sleep(_lua: &Lua, n: u64) -> Result<&'static str> {
-    ///     Delay::new(Duration::from_millis(n)).await;
-    ///     Ok("done")
-    /// }
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<()> {
-    ///     let lua = Lua::new();
-    ///     lua.globals().set("sleep", lua.create_async_function(sleep)?)?;
-    ///     let res: String = lua.load("return sleep(...)").call_async(100).await?; // Sleep 100ms
-    ///     assert_eq!(res, "done");
-    ///     Ok(())
-    /// }
-    /// ```
-    ///
-    /// [`Thread`]: crate::Thread
-    /// [`AsyncThread`]: crate::AsyncThread
-    #[cfg(feature = "async")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-    pub fn create_async_function<'lua, A, R, F, FR>(&'lua self, func: F) -> Result<Function<'lua>>
-    where
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> FR,
-        FR: 'lua + Future<Output = Result<R>>,
-    {
-        self.create_async_callback(Box::new(move |lua, args| {
-            let args = match A::from_lua_multi(args, lua) {
-                Ok(args) => args,
-                Err(e) => return Box::pin(future::err(e)),
-            };
-            Box::pin(func(lua, args).and_then(move |ret| future::ready(ret.to_lua_multi(lua))))
-        }))
-    }
+	/// Wraps a Rust async function or closure, creating a callable Lua function handle to it.
+	///
+	/// While executing the function Rust will poll Future and if the result is not ready, call
+	/// `yield()` passing internal representation of a `Poll::Pending` value.
+	///
+	/// The function must be called inside Lua coroutine ([`Thread`]) to be able to suspend its execution.
+	/// An executor should be used to poll [`AsyncThread`] and mlua will take a provided Waker
+	/// in that case. Otherwise noop waker will be used if try to call the function outside of Rust
+	/// executors.
+	///
+	/// The family of `call_async()` functions takes care about creating [`Thread`].
+	///
+	/// Requires `feature = "async"`
+	///
+	/// # Examples
+	///
+	/// Non blocking sleep:
+	///
+	/// ```
+	/// use std::time::Duration;
+	/// use futures_timer::Delay;
+	/// use mlua::{Lua, Result};
+	///
+	/// async fn sleep(_lua: &Lua, n: u64) -> Result<&'static str> {
+	///     Delay::new(Duration::from_millis(n)).await;
+	///     Ok("done")
+	/// }
+	///
+	/// #[tokio::main]
+	/// async fn main() -> Result<()> {
+	///     let lua = Lua::new();
+	///     lua.globals().set("sleep", lua.create_async_function(sleep)?)?;
+	///     let res: String = lua.load("return sleep(...)").call_async(100).await?; // Sleep 100ms
+	///     assert_eq!(res, "done");
+	///     Ok(())
+	/// }
+	/// ```
+	///
+	/// [`Thread`]: crate::Thread
+	/// [`AsyncThread`]: crate::AsyncThread
+	#[cfg(feature = "async")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+	pub fn create_async_function<'lua, A, R, F, FR>(&'lua self, func: F) -> Result<Function>
+		where
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + Fn(&Lua, A) -> FR,
+			FR: 'lua + Future<Output=Result<R>>,
+	{
+		self.create_async_callback(Box::new(move |lua, args| {
+			let args = match A::from_lua_multi(args, lua) {
+				Ok(args) => args,
+				Err(e) => return Box::pin(future::err(e)),
+			};
+			Box::pin(func(lua, args).and_then(move |ret| future::ready(ret.to_lua_multi(lua))))
+		}))
+	}
 
-    /// Wraps a Lua function into a new thread (or coroutine).
-    ///
-    /// Equivalent to `coroutine.create`.
-    pub fn create_thread<'lua>(&'lua self, func: Function<'lua>) -> Result<Thread<'lua>> {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 3)?;
+	/// Wraps a Lua function into a new thread (or coroutine).
+	///
+	/// Equivalent to `coroutine.create`.
+	pub fn create_thread(&self, func: Function) -> Result<Thread> {
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 3)?;
 
-            let thread_state = protect_lua!(self.state, 0, 1, |state| ffi::lua_newthread(state))?;
-            self.push_ref(&func.0);
-            ffi::lua_xmove(self.state, thread_state, 1);
+			let thread_state = protect_lua!(self.state, 0, 1, |state| ffi::lua_newthread(state))?;
+			self.push_ref(&func.0);
+			ffi::lua_xmove(self.state, thread_state, 1);
 
-            Ok(Thread(self.pop_ref()))
-        }
-    }
+			Ok(Thread(self.pop_ref()))
+		}
+	}
 
-    /// Wraps a Lua function into a new or recycled thread (coroutine).
-    #[cfg(feature = "async")]
-    pub(crate) fn create_recycled_thread<'lua>(
-        &'lua self,
-        func: Function<'lua>,
-    ) -> Result<Thread<'lua>> {
-        #[cfg(any(
-            feature = "lua54",
-            all(feature = "luajit", feature = "vendored"),
-            feature = "luau",
-        ))]
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 1)?;
+	/// Wraps a Lua function into a new or recycled thread (coroutine).
+	#[cfg(feature = "async")]
+	pub(crate) fn create_recycled_thread(
+		&self,
+		func: Function,
+	) -> Result<Thread> {
+		#[cfg(any(
+		feature = "lua54",
+		all(feature = "luajit", feature = "vendored"),
+		feature = "luau",
+		))]
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 1)?;
 
-            let extra = &mut *self.extra.get();
-            if let Some(index) = extra.recycled_thread_cache.pop() {
-                let thread_state = ffi::lua_tothread(extra.ref_thread, index);
-                self.push_ref(&func.0);
-                ffi::lua_xmove(self.state, thread_state, 1);
+			let extra = &mut *self.extra.get();
+			if let Some(index) = extra.recycled_thread_cache.pop() {
+				let thread_state = ffi::lua_tothread(extra.ref_thread, index);
+				self.push_ref(&func.0);
+				ffi::lua_xmove(self.state, thread_state, 1);
 
-                #[cfg(feature = "luau")]
-                {
-                    // Inherit `LUA_GLOBALSINDEX` from the caller
-                    ffi::lua_xpush(self.state, thread_state, ffi::LUA_GLOBALSINDEX);
-                    ffi::lua_replace(thread_state, ffi::LUA_GLOBALSINDEX);
-                }
+				#[cfg(feature = "luau")]
+				{
+					// Inherit `LUA_GLOBALSINDEX` from the caller
+					ffi::lua_xpush(self.state, thread_state, ffi::LUA_GLOBALSINDEX);
+					ffi::lua_replace(thread_state, ffi::LUA_GLOBALSINDEX);
+				}
 
-                return Ok(Thread(LuaRef { lua: self, index }));
-            }
-        };
-        self.create_thread(func)
-    }
+				return Ok(Thread(LuaRef { lua: LuaWeakRef::new(self), index }));
+			}
+		};
+		self.create_thread(func)
+	}
 
-    /// Resets thread (coroutine) and returns to the cache for later use.
-    #[cfg(feature = "async")]
-    #[cfg(any(
-        feature = "lua54",
-        all(feature = "luajit", feature = "vendored"),
-        feature = "luau",
-    ))]
-    pub(crate) unsafe fn recycle_thread(&self, thread: &mut Thread) {
-        let extra = &mut *self.extra.get();
-        let thread_state = ffi::lua_tothread(extra.ref_thread, thread.0.index);
-        if extra.recycled_thread_cache.len() < extra.recycled_thread_cache.capacity() {
-            #[cfg(feature = "lua54")]
-            let status = ffi::lua_resetthread(thread_state);
-            #[cfg(feature = "lua54")]
-            if status != ffi::LUA_OK {
-                return;
-            }
-            #[cfg(all(feature = "luajit", feature = "vendored"))]
-            ffi::lua_resetthread(self.state, thread_state);
-            #[cfg(feature = "luau")]
-            ffi::lua_resetthread(thread_state);
-            extra.recycled_thread_cache.push(thread.0.index);
-            thread.0.index = 0;
-        }
-    }
+	/// Resets thread (coroutine) and returns to the cache for later use.
+	#[cfg(feature = "async")]
+	#[cfg(any(
+	feature = "lua54",
+	all(feature = "luajit", feature = "vendored"),
+	feature = "luau",
+	))]
+	pub(crate) unsafe fn recycle_thread(&self, thread: &mut Thread) {
+		let extra = &mut *self.extra.get();
+		let thread_state = ffi::lua_tothread(extra.ref_thread, thread.0.index);
+		if extra.recycled_thread_cache.len() < extra.recycled_thread_cache.capacity() {
+			#[cfg(feature = "lua54")]
+				let status = ffi::lua_resetthread(thread_state);
+			#[cfg(feature = "lua54")]
+			if status != ffi::LUA_OK {
+				return;
+			}
+			#[cfg(all(feature = "luajit", feature = "vendored"))]
+			ffi::lua_resetthread(self.state, thread_state);
+			#[cfg(feature = "luau")]
+			ffi::lua_resetthread(thread_state);
+			extra.recycled_thread_cache.push(thread.0.index);
+			thread.0.index = 0;
+		}
+	}
 
-    /// Create a Lua userdata object from a custom userdata type.
-    pub fn create_userdata<T>(&self, data: T) -> Result<AnyUserData>
-    where
-        T: 'static + MaybeSend + UserData,
-    {
-        unsafe { self.make_userdata(UserDataCell::new(data)) }
-    }
+	/// Create a Lua userdata object from a custom userdata type.
+	pub fn create_userdata<T>(&self, data: T) -> Result<AnyUserData>
+		where
+			T: 'static + MaybeSend + UserData,
+	{
+		unsafe { self.make_userdata(UserDataCell::new(data)) }
+	}
 
-    /// Create a Lua userdata object from a custom serializable userdata type.
-    ///
-    /// Requires `feature = "serialize"`
-    #[cfg(feature = "serialize")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "serialize")))]
-    pub fn create_ser_userdata<T>(&self, data: T) -> Result<AnyUserData>
-    where
-        T: 'static + MaybeSend + UserData + Serialize,
-    {
-        unsafe { self.make_userdata(UserDataCell::new_ser(data)) }
-    }
+	/// Create a Lua userdata object from a custom serializable userdata type.
+	///
+	/// Requires `feature = "serialize"`
+	#[cfg(feature = "serialize")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "serialize")))]
+	pub fn create_ser_userdata<T>(&self, data: T) -> Result<AnyUserData>
+		where
+			T: 'static + MaybeSend + UserData + Serialize,
+	{
+		unsafe { self.make_userdata(UserDataCell::new_ser(data)) }
+	}
 
-    /// Returns a handle to the global environment.
-    pub fn globals(&self) -> Table {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            assert_stack(self.state, 1);
-            #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
-            ffi::lua_rawgeti(self.state, ffi::LUA_REGISTRYINDEX, ffi::LUA_RIDX_GLOBALS);
-            #[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
-            ffi::lua_pushvalue(self.state, ffi::LUA_GLOBALSINDEX);
-            Table(self.pop_ref())
-        }
-    }
+	/// Returns a handle to the global environment.
+	pub fn globals(&self) -> Table {
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			assert_stack(self.state, 1);
+			#[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
+			ffi::lua_rawgeti(self.state, ffi::LUA_REGISTRYINDEX, ffi::LUA_RIDX_GLOBALS);
+			#[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
+			ffi::lua_pushvalue(self.state, ffi::LUA_GLOBALSINDEX);
+			Table(self.pop_ref())
+		}
+	}
 
-    /// Returns a handle to the active `Thread`. For calls to `Lua` this will be the main Lua thread,
-    /// for parameters given to a callback, this will be whatever Lua thread called the callback.
-    pub fn current_thread(&self) -> Thread {
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            assert_stack(self.state, 1);
-            ffi::lua_pushthread(self.state);
-            Thread(self.pop_ref())
-        }
-    }
+	/// Returns a handle to the active `Thread`. For calls to `Lua` this will be the main Lua thread,
+	/// for parameters given to a callback, this will be whatever Lua thread called the callback.
+	pub fn current_thread(&self) -> Thread {
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			assert_stack(self.state, 1);
+			ffi::lua_pushthread(self.state);
+			Thread(self.pop_ref())
+		}
+	}
 
-    /// Calls the given function with a `Scope` parameter, giving the function the ability to create
-    /// userdata and callbacks from rust types that are !Send or non-'static.
-    ///
-    /// The lifetime of any function or userdata created through `Scope` lasts only until the
-    /// completion of this method call, on completion all such created values are automatically
-    /// dropped and Lua references to them are invalidated. If a script accesses a value created
-    /// through `Scope` outside of this method, a Lua error will result. Since we can ensure the
-    /// lifetime of values created through `Scope`, and we know that `Lua` cannot be sent to another
-    /// thread while `Scope` is live, it is safe to allow !Send datatypes and whose lifetimes only
-    /// outlive the scope lifetime.
-    ///
-    /// Inside the scope callback, all handles created through Scope will share the same unique 'lua
-    /// lifetime of the parent `Lua`. This allows scoped and non-scoped values to be mixed in
-    /// API calls, which is very useful (e.g. passing a scoped userdata to a non-scoped function).
-    /// However, this also enables handles to scoped values to be trivially leaked from the given
-    /// callback. This is not dangerous, though!  After the callback returns, all scoped values are
-    /// invalidated, which means that though references may exist, the Rust types backing them have
-    /// dropped. `Function` types will error when called, and `AnyUserData` will be typeless. It
-    /// would be impossible to prevent handles to scoped values from escaping anyway, since you
-    /// would always be able to smuggle them through Lua state.
-    pub fn scope<'lua, 'scope, R, F>(&'lua self, f: F) -> Result<R>
-    where
-        'lua: 'scope,
-        R: 'static,
-        F: FnOnce(&Scope<'lua, 'scope>) -> Result<R>,
-    {
-        f(&Scope::new(self))
-    }
+	/// Calls the given function with a `Scope` parameter, giving the function the ability to create
+	/// userdata and callbacks from rust types that are !Send or non-'static.
+	///
+	/// The lifetime of any function or userdata created through `Scope` lasts only until the
+	/// completion of this method call, on completion all such created values are automatically
+	/// dropped and Lua references to them are invalidated. If a script accesses a value created
+	/// through `Scope` outside of this method, a Lua error will result. Since we can ensure the
+	/// lifetime of values created through `Scope`, and we know that `Lua` cannot be sent to another
+	/// thread while `Scope` is live, it is safe to allow !Send datatypes and whose lifetimes only
+	/// outlive the scope lifetime.
+	///
+	/// Inside the scope callback, all handles created through Scope will share the same unique 'lua
+	/// lifetime of the parent `Lua`. This allows scoped and non-scoped values to be mixed in
+	/// API calls, which is very useful (e.g. passing a scoped userdata to a non-scoped function).
+	/// However, this also enables handles to scoped values to be trivially leaked from the given
+	/// callback. This is not dangerous, though!  After the callback returns, all scoped values are
+	/// invalidated, which means that though references may exist, the Rust types backing them have
+	/// dropped. `Function` types will error when called, and `AnyUserData` will be typeless. It
+	/// would be impossible to prevent handles to scoped values from escaping anyway, since you
+	/// would always be able to smuggle them through Lua state.
+	pub fn scope<'scope, R, F>(&self, f: F) -> Result<R>
+		where
+			R: 'static,
+			F: FnOnce(&Scope<'scope>) -> Result<R>,
+	{
+		f(&Scope::new(self))
+	}
 
-    /// An asynchronous version of [`scope`] that allows to create scoped async functions and
-    /// execute them.
-    ///
-    /// Requires `feature = "async"`
-    ///
-    /// [`scope`]: #method.scope
-    #[cfg(feature = "async")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-    pub fn async_scope<'lua, 'scope, R, F, FR>(
-        &'lua self,
-        f: F,
-    ) -> LocalBoxFuture<'scope, Result<R>>
-    where
-        'lua: 'scope,
-        R: 'static,
-        F: FnOnce(Scope<'lua, 'scope>) -> FR,
-        FR: 'scope + Future<Output = Result<R>>,
-    {
-        Box::pin(f(Scope::new(self)))
-    }
+	/// An asynchronous version of [`scope`] that allows to create scoped async functions and
+	/// execute them.
+	///
+	/// Requires `feature = "async"`
+	///
+	/// [`scope`]: #method.scope
+	#[cfg(feature = "async")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+	pub fn async_scope<'scope, R, F, FR>(
+		&self,
+		f: F,
+	) -> LocalBoxFuture<'scope, Result<R>>
+		where
+			R: 'static,
+			F: FnOnce(Scope<'scope>) -> FR,
+			FR: 'scope + Future<Output=Result<R>>,
+	{
+		Box::pin(f(Scope::new(self)))
+	}
 
-    /// Attempts to coerce a Lua value into a String in a manner consistent with Lua's internal
-    /// behavior.
-    ///
-    /// To succeed, the value must be a string (in which case this is a no-op), an integer, or a
-    /// number.
-    pub fn coerce_string<'lua>(&'lua self, v: Value<'lua>) -> Result<Option<String<'lua>>> {
-        Ok(match v {
-            Value::String(s) => Some(s),
-            v => unsafe {
-                let _sg = StackGuard::new(self.state);
-                check_stack(self.state, 4)?;
+	/// Attempts to coerce a Lua value into a String in a manner consistent with Lua's internal
+	/// behavior.
+	///
+	/// To succeed, the value must be a string (in which case this is a no-op), an integer, or a
+	/// number.
+	pub fn coerce_string(&self, v: Value) -> Result<Option<String>> {
+		Ok(match v {
+			Value::String(s) => Some(s),
+			v => unsafe {
+				let _sg = StackGuard::new(self.state);
+				check_stack(self.state, 4)?;
 
-                self.push_value(v)?;
-                let res = protect_lua!(self.state, 1, 1, |state| {
+				self.push_value(v)?;
+				let res = protect_lua!(self.state, 1, 1, |state| {
                     ffi::lua_tolstring(state, -1, ptr::null_mut())
                 })?;
-                if !res.is_null() {
-                    Some(String(self.pop_ref()))
-                } else {
-                    None
-                }
-            },
-        })
-    }
+				if !res.is_null() {
+					Some(String(self.pop_ref()))
+				} else {
+					None
+				}
+			},
+		})
+	}
 
-    /// Attempts to coerce a Lua value into an integer in a manner consistent with Lua's internal
-    /// behavior.
-    ///
-    /// To succeed, the value must be an integer, a floating point number that has an exact
-    /// representation as an integer, or a string that can be converted to an integer. Refer to the
-    /// Lua manual for details.
-    pub fn coerce_integer(&self, v: Value) -> Result<Option<Integer>> {
-        Ok(match v {
-            Value::Integer(i) => Some(i),
-            v => unsafe {
-                let _sg = StackGuard::new(self.state);
-                check_stack(self.state, 2)?;
+	/// Attempts to coerce a Lua value into an integer in a manner consistent with Lua's internal
+	/// behavior.
+	///
+	/// To succeed, the value must be an integer, a floating point number that has an exact
+	/// representation as an integer, or a string that can be converted to an integer. Refer to the
+	/// Lua manual for details.
+	pub fn coerce_integer(&self, v: Value) -> Result<Option<Integer>> {
+		Ok(match v {
+			Value::Integer(i) => Some(i),
+			v => unsafe {
+				let _sg = StackGuard::new(self.state);
+				check_stack(self.state, 2)?;
 
-                self.push_value(v)?;
-                let mut isint = 0;
-                let i = ffi::lua_tointegerx(self.state, -1, &mut isint);
-                if isint == 0 {
-                    None
-                } else {
-                    Some(i)
-                }
-            },
-        })
-    }
+				self.push_value(v)?;
+				let mut isint = 0;
+				let i = ffi::lua_tointegerx(self.state, -1, &mut isint);
+				if isint == 0 {
+					None
+				} else {
+					Some(i)
+				}
+			},
+		})
+	}
 
-    /// Attempts to coerce a Lua value into a Number in a manner consistent with Lua's internal
-    /// behavior.
-    ///
-    /// To succeed, the value must be a number or a string that can be converted to a number. Refer
-    /// to the Lua manual for details.
-    pub fn coerce_number(&self, v: Value) -> Result<Option<Number>> {
-        Ok(match v {
-            Value::Number(n) => Some(n),
-            v => unsafe {
-                let _sg = StackGuard::new(self.state);
-                check_stack(self.state, 2)?;
+	/// Attempts to coerce a Lua value into a Number in a manner consistent with Lua's internal
+	/// behavior.
+	///
+	/// To succeed, the value must be a number or a string that can be converted to a number. Refer
+	/// to the Lua manual for details.
+	pub fn coerce_number(&self, v: Value) -> Result<Option<Number>> {
+		Ok(match v {
+			Value::Number(n) => Some(n),
+			v => unsafe {
+				let _sg = StackGuard::new(self.state);
+				check_stack(self.state, 2)?;
 
-                self.push_value(v)?;
-                let mut isnum = 0;
-                let n = ffi::lua_tonumberx(self.state, -1, &mut isnum);
-                if isnum == 0 {
-                    None
-                } else {
-                    Some(n)
-                }
-            },
-        })
-    }
+				self.push_value(v)?;
+				let mut isnum = 0;
+				let n = ffi::lua_tonumberx(self.state, -1, &mut isnum);
+				if isnum == 0 {
+					None
+				} else {
+					Some(n)
+				}
+			},
+		})
+	}
 
-    /// Converts a value that implements `ToLua` into a `Value` instance.
-    pub fn pack<'lua, T: ToLua<'lua>>(&'lua self, t: T) -> Result<Value<'lua>> {
-        t.to_lua(self)
-    }
+	/// Converts a value that implements `ToLua` into a `Value` instance.
+	pub fn pack<'lua, T: ToLua>(&'lua self, t: T) -> Result<Value> {
+		t.to_lua(self)
+	}
 
-    /// Converts a `Value` instance into a value that implements `FromLua`.
-    pub fn unpack<'lua, T: FromLua<'lua>>(&'lua self, value: Value<'lua>) -> Result<T> {
-        T::from_lua(value, self)
-    }
+	/// Converts a `Value` instance into a value that implements `FromLua`.
+	pub fn unpack<'lua, T: FromLua>(&'lua self, value: Value) -> Result<T> {
+		T::from_lua(value, self)
+	}
 
-    /// Converts a value that implements `ToLuaMulti` into a `MultiValue` instance.
-    pub fn pack_multi<'lua, T: ToLuaMulti<'lua>>(&'lua self, t: T) -> Result<MultiValue<'lua>> {
-        t.to_lua_multi(self)
-    }
+	/// Converts a value that implements `ToLuaMulti` into a `MultiValue` instance.
+	pub fn pack_multi<'lua, T: ToLuaMulti>(&'lua self, t: T) -> Result<MultiValue> {
+		t.to_lua_multi(self)
+	}
 
-    /// Converts a `MultiValue` instance into a value that implements `FromLuaMulti`.
-    pub fn unpack_multi<'lua, T: FromLuaMulti<'lua>>(
-        &'lua self,
-        value: MultiValue<'lua>,
-    ) -> Result<T> {
-        T::from_lua_multi(value, self)
-    }
+	/// Converts a `MultiValue` instance into a value that implements `FromLuaMulti`.
+	pub fn unpack_multi<'lua, T: FromLuaMulti>(
+		&'lua self,
+		value: MultiValue,
+	) -> Result<T> {
+		T::from_lua_multi(value, self)
+	}
 
-    /// Set a value in the Lua registry based on a string name.
-    ///
-    /// This value will be available to rust from all `Lua` instances which share the same main
-    /// state.
-    pub fn set_named_registry_value<'lua, S, T>(&'lua self, name: &S, t: T) -> Result<()>
-    where
-        S: AsRef<[u8]> + ?Sized,
-        T: ToLua<'lua>,
-    {
-        let t = t.to_lua(self)?;
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 5)?;
+	/// Set a value in the Lua registry based on a string name.
+	///
+	/// This value will be available to rust from all `Lua` instances which share the same main
+	/// state.
+	pub fn set_named_registry_value<'lua, S, T>(&'lua self, name: &S, t: T) -> Result<()>
+		where
+			S: AsRef<[u8]> + ?Sized,
+			T: ToLua,
+	{
+		let t = t.to_lua(self)?;
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 5)?;
 
-            self.push_value(t)?;
-            rawset_field(self.state, ffi::LUA_REGISTRYINDEX, name)
-        }
-    }
+			self.push_value(t)?;
+			rawset_field(self.state, ffi::LUA_REGISTRYINDEX, name)
+		}
+	}
 
-    /// Get a value from the Lua registry based on a string name.
-    ///
-    /// Any Lua instance which shares the underlying main state may call this method to
-    /// get a value previously set by [`set_named_registry_value`].
-    ///
-    /// [`set_named_registry_value`]: #method.set_named_registry_value
-    pub fn named_registry_value<'lua, S, T>(&'lua self, name: &S) -> Result<T>
-    where
-        S: AsRef<[u8]> + ?Sized,
-        T: FromLua<'lua>,
-    {
-        let value = unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 3)?;
+	/// Get a value from the Lua registry based on a string name.
+	///
+	/// Any Lua instance which shares the underlying main state may call this method to
+	/// get a value previously set by [`set_named_registry_value`].
+	///
+	/// [`set_named_registry_value`]: #method.set_named_registry_value
+	pub fn named_registry_value<'lua, S, T>(&'lua self, name: &S) -> Result<T>
+		where
+			S: AsRef<[u8]> + ?Sized,
+			T: FromLua,
+	{
+		let value = unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 3)?;
 
-            push_string(self.state, name)?;
-            ffi::lua_rawget(self.state, ffi::LUA_REGISTRYINDEX);
+			push_string(self.state, name)?;
+			ffi::lua_rawget(self.state, ffi::LUA_REGISTRYINDEX);
 
-            self.pop_value()
-        };
-        T::from_lua(value, self)
-    }
+			self.pop_value()
+		};
+		T::from_lua(value, self)
+	}
 
-    /// Removes a named value in the Lua registry.
-    ///
-    /// Equivalent to calling [`set_named_registry_value`] with a value of Nil.
-    ///
-    /// [`set_named_registry_value`]: #method.set_named_registry_value
-    pub fn unset_named_registry_value<S>(&self, name: &S) -> Result<()>
-    where
-        S: AsRef<[u8]> + ?Sized,
-    {
-        self.set_named_registry_value(name, Nil)
-    }
+	/// Removes a named value in the Lua registry.
+	///
+	/// Equivalent to calling [`set_named_registry_value`] with a value of Nil.
+	///
+	/// [`set_named_registry_value`]: #method.set_named_registry_value
+	pub fn unset_named_registry_value<S>(&self, name: &S) -> Result<()>
+		where
+			S: AsRef<[u8]> + ?Sized,
+	{
+		self.set_named_registry_value(name, Nil)
+	}
 
-    /// Place a value in the Lua registry with an auto-generated key.
-    ///
-    /// This value will be available to Rust from all `Lua` instances which share the same main
-    /// state.
-    ///
-    /// Be warned, garbage collection of values held inside the registry is not automatic, see
-    /// [`RegistryKey`] for more details.
-    /// However, dropped [`RegistryKey`]s automatically reused to store new values.
-    ///
-    /// [`RegistryKey`]: crate::RegistryKey
-    pub fn create_registry_value<'lua, T: ToLua<'lua>>(&'lua self, t: T) -> Result<RegistryKey> {
-        let t = t.to_lua(self)?;
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 4)?;
+	/// Place a value in the Lua registry with an auto-generated key.
+	///
+	/// This value will be available to Rust from all `Lua` instances which share the same main
+	/// state.
+	///
+	/// Be warned, garbage collection of values held inside the registry is not automatic, see
+	/// [`RegistryKey`] for more details.
+	/// However, dropped [`RegistryKey`]s automatically reused to store new values.
+	///
+	/// [`RegistryKey`]: crate::RegistryKey
+	pub fn create_registry_value<'lua, T: ToLua>(&'lua self, t: T) -> Result<RegistryKey> {
+		let t = t.to_lua(self)?;
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 4)?;
 
-            let unref_list = (*self.extra.get()).registry_unref_list.clone();
-            self.push_value(t)?;
+			let unref_list = (*self.extra.get()).registry_unref_list.clone();
+			self.push_value(t)?;
 
-            // Try to reuse previously allocated RegistryKey
-            let unref_list2 = unref_list.clone();
-            let mut unref_list2 = mlua_expect!(unref_list2.lock(), "unref list poisoned");
-            if let Some(registry_id) = unref_list2.as_mut().and_then(|x| x.pop()) {
-                // It must be safe to replace the value without triggering memory error
-                ffi::lua_rawseti(self.state, ffi::LUA_REGISTRYINDEX, registry_id as Integer);
-                return Ok(RegistryKey {
-                    registry_id,
-                    unref_list,
-                });
-            }
+			// Try to reuse previously allocated RegistryKey
+			let unref_list2 = unref_list.clone();
+			let mut unref_list2 = mlua_expect!(unref_list2.lock(), "unref list poisoned");
+			if let Some(registry_id) = unref_list2.as_mut().and_then(|x| x.pop()) {
+				// It must be safe to replace the value without triggering memory error
+				ffi::lua_rawseti(self.state, ffi::LUA_REGISTRYINDEX, registry_id as Integer);
+				return Ok(RegistryKey {
+					registry_id,
+					unref_list,
+				});
+			}
 
-            // Allocate a new RegistryKey
-            let registry_id = protect_lua!(self.state, 1, 0, |state| {
+			// Allocate a new RegistryKey
+			let registry_id = protect_lua!(self.state, 1, 0, |state| {
                 ffi::luaL_ref(state, ffi::LUA_REGISTRYINDEX)
             })?;
 
-            Ok(RegistryKey {
-                registry_id,
-                unref_list,
-            })
-        }
-    }
+			Ok(RegistryKey {
+				registry_id,
+				unref_list,
+			})
+		}
+	}
 
-    /// Get a value from the Lua registry by its `RegistryKey`
-    ///
-    /// Any Lua instance which shares the underlying main state may call this method to get a value
-    /// previously placed by [`create_registry_value`].
-    ///
-    /// [`create_registry_value`]: #method.create_registry_value
-    pub fn registry_value<'lua, T: FromLua<'lua>>(&'lua self, key: &RegistryKey) -> Result<T> {
-        if !self.owns_registry_value(key) {
-            return Err(Error::MismatchedRegistryKey);
-        }
+	/// Get a value from the Lua registry by its `RegistryKey`
+	///
+	/// Any Lua instance which shares the underlying main state may call this method to get a value
+	/// previously placed by [`create_registry_value`].
+	///
+	/// [`create_registry_value`]: #method.create_registry_value
+	pub fn registry_value<'lua, T: FromLua>(&'lua self, key: &RegistryKey) -> Result<T> {
+		if !self.owns_registry_value(key) {
+			return Err(Error::MismatchedRegistryKey);
+		}
 
-        let value = unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 1)?;
+		let value = unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 1)?;
 
-            ffi::lua_rawgeti(
-                self.state,
-                ffi::LUA_REGISTRYINDEX,
-                key.registry_id as Integer,
-            );
-            self.pop_value()
-        };
-        T::from_lua(value, self)
-    }
+			ffi::lua_rawgeti(
+				self.state,
+				ffi::LUA_REGISTRYINDEX,
+				key.registry_id as Integer,
+			);
+			self.pop_value()
+		};
+		T::from_lua(value, self)
+	}
 
-    /// Removes a value from the Lua registry.
-    ///
-    /// You may call this function to manually remove a value placed in the registry with
-    /// [`create_registry_value`]. In addition to manual `RegistryKey` removal, you can also call
-    /// [`expire_registry_values`] to automatically remove values from the registry whose
-    /// `RegistryKey`s have been dropped.
-    ///
-    /// [`create_registry_value`]: #method.create_registry_value
-    /// [`expire_registry_values`]: #method.expire_registry_values
-    pub fn remove_registry_value(&self, key: RegistryKey) -> Result<()> {
-        if !self.owns_registry_value(&key) {
-            return Err(Error::MismatchedRegistryKey);
-        }
-        unsafe {
-            ffi::luaL_unref(self.state, ffi::LUA_REGISTRYINDEX, key.take());
-        }
-        Ok(())
-    }
+	/// Removes a value from the Lua registry.
+	///
+	/// You may call this function to manually remove a value placed in the registry with
+	/// [`create_registry_value`]. In addition to manual `RegistryKey` removal, you can also call
+	/// [`expire_registry_values`] to automatically remove values from the registry whose
+	/// `RegistryKey`s have been dropped.
+	///
+	/// [`create_registry_value`]: #method.create_registry_value
+	/// [`expire_registry_values`]: #method.expire_registry_values
+	pub fn remove_registry_value(&self, key: RegistryKey) -> Result<()> {
+		if !self.owns_registry_value(&key) {
+			return Err(Error::MismatchedRegistryKey);
+		}
+		unsafe {
+			ffi::luaL_unref(self.state, ffi::LUA_REGISTRYINDEX, key.take());
+		}
+		Ok(())
+	}
 
-    /// Replaces a value in the Lua registry by its `RegistryKey`.
-    ///
-    /// See [`create_registry_value`] for more details.
-    ///
-    /// [`create_registry_value`]: #method.create_registry_value
-    pub fn replace_registry_value<'lua, T: ToLua<'lua>>(
-        &'lua self,
-        key: &RegistryKey,
-        t: T,
-    ) -> Result<()> {
-        if !self.owns_registry_value(key) {
-            return Err(Error::MismatchedRegistryKey);
-        }
+	/// Replaces a value in the Lua registry by its `RegistryKey`.
+	///
+	/// See [`create_registry_value`] for more details.
+	///
+	/// [`create_registry_value`]: #method.create_registry_value
+	pub fn replace_registry_value<'lua, T: ToLua>(
+		&'lua self,
+		key: &RegistryKey,
+		t: T,
+	) -> Result<()> {
+		if !self.owns_registry_value(key) {
+			return Err(Error::MismatchedRegistryKey);
+		}
 
-        let t = t.to_lua(self)?;
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 2)?;
+		let t = t.to_lua(self)?;
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 2)?;
 
-            self.push_value(t)?;
-            // It must be safe to replace the value without triggering memory error
-            ffi::lua_rawseti(
-                self.state,
-                ffi::LUA_REGISTRYINDEX,
-                key.registry_id as Integer,
-            );
+			self.push_value(t)?;
+			// It must be safe to replace the value without triggering memory error
+			ffi::lua_rawseti(
+				self.state,
+				ffi::LUA_REGISTRYINDEX,
+				key.registry_id as Integer,
+			);
 
-            Ok(())
-        }
-    }
+			Ok(())
+		}
+	}
 
-    /// Returns true if the given `RegistryKey` was created by a `Lua` which shares the underlying
-    /// main state with this `Lua` instance.
-    ///
-    /// Other than this, methods that accept a `RegistryKey` will return
-    /// `Error::MismatchedRegistryKey` if passed a `RegistryKey` that was not created with a
-    /// matching `Lua` state.
-    pub fn owns_registry_value(&self, key: &RegistryKey) -> bool {
-        let registry_unref_list = unsafe { &(*self.extra.get()).registry_unref_list };
-        Arc::ptr_eq(&key.unref_list, registry_unref_list)
-    }
+	/// Returns true if the given `RegistryKey` was created by a `Lua` which shares the underlying
+	/// main state with this `Lua` instance.
+	///
+	/// Other than this, methods that accept a `RegistryKey` will return
+	/// `Error::MismatchedRegistryKey` if passed a `RegistryKey` that was not created with a
+	/// matching `Lua` state.
+	pub fn owns_registry_value(&self, key: &RegistryKey) -> bool {
+		let registry_unref_list = unsafe { &(*self.extra.get()).registry_unref_list };
+		Arc::ptr_eq(&key.unref_list, registry_unref_list)
+	}
 
-    /// Remove any registry values whose `RegistryKey`s have all been dropped.
-    ///
-    /// Unlike normal handle values, `RegistryKey`s do not automatically remove themselves on Drop,
-    /// but you can call this method to remove any unreachable registry values not manually removed
-    /// by `Lua::remove_registry_value`.
-    pub fn expire_registry_values(&self) {
-        unsafe {
-            let mut unref_list = mlua_expect!(
+	/// Remove any registry values whose `RegistryKey`s have all been dropped.
+	///
+	/// Unlike normal handle values, `RegistryKey`s do not automatically remove themselves on Drop,
+	/// but you can call this method to remove any unreachable registry values not manually removed
+	/// by `Lua::remove_registry_value`.
+	pub fn expire_registry_values(&self) {
+		unsafe {
+			let mut unref_list = mlua_expect!(
                 (*self.extra.get()).registry_unref_list.lock(),
                 "unref list poisoned"
             );
-            let unref_list = mem::replace(&mut *unref_list, Some(Vec::new()));
-            for id in mlua_expect!(unref_list, "unref list not set") {
-                ffi::luaL_unref(self.state, ffi::LUA_REGISTRYINDEX, id);
-            }
-        }
-    }
+			let unref_list = mem::replace(&mut *unref_list, Some(Vec::new()));
+			for id in mlua_expect!(unref_list, "unref list not set") {
+				ffi::luaL_unref(self.state, ffi::LUA_REGISTRYINDEX, id);
+			}
+		}
+	}
 
-    /// Sets or replaces an application data object of type `T`.
-    ///
-    /// Application data could be accessed at any time by using [`Lua::app_data_ref()`] or [`Lua::app_data_mut()`]
-    /// methods where `T` is the data type.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use mlua::{Lua, Result};
-    ///
-    /// fn hello(lua: &Lua, _: ()) -> Result<()> {
-    ///     let mut s = lua.app_data_mut::<&str>().unwrap();
-    ///     assert_eq!(*s, "hello");
-    ///     *s = "world";
-    ///     Ok(())
-    /// }
-    ///
-    /// fn main() -> Result<()> {
-    ///     let lua = Lua::new();
-    ///     lua.set_app_data("hello");
-    ///     lua.create_function(hello)?.call(())?;
-    ///     let s = lua.app_data_ref::<&str>().unwrap();
-    ///     assert_eq!(*s, "world");
-    ///     Ok(())
-    /// }
-    /// ```
-    pub fn set_app_data<T: 'static + MaybeSend>(&self, data: T) {
-        let extra = unsafe { &mut (*self.extra.get()) };
-        extra
-            .app_data
-            .try_borrow_mut()
-            .expect("cannot borrow mutably app data container")
-            .insert(TypeId::of::<T>(), Box::new(data));
-    }
+	/// Sets or replaces an application data object of type `T`.
+	///
+	/// Application data could be accessed at any time by using [`Lua::app_data_ref()`] or [`Lua::app_data_mut()`]
+	/// methods where `T` is the data type.
+	///
+	/// # Examples
+	///
+	/// ```
+	/// use mlua::{Lua, Result};
+	///
+	/// fn hello(lua: &Lua, _: ()) -> Result<()> {
+	///     let mut s = lua.app_data_mut::<&str>().unwrap();
+	///     assert_eq!(*s, "hello");
+	///     *s = "world";
+	///     Ok(())
+	/// }
+	///
+	/// fn main() -> Result<()> {
+	///     let lua = Lua::new();
+	///     lua.set_app_data("hello");
+	///     lua.create_function(hello)?.call(())?;
+	///     let s = lua.app_data_ref::<&str>().unwrap();
+	///     assert_eq!(*s, "world");
+	///     Ok(())
+	/// }
+	/// ```
+	pub fn set_app_data<T: 'static + MaybeSend>(&self, data: T) {
+		let extra = unsafe { &mut (*self.extra.get()) };
+		extra
+			.app_data
+			.try_borrow_mut()
+			.expect("cannot borrow mutably app data container")
+			.insert(TypeId::of::<T>(), Box::new(data));
+	}
 
-    /// Gets a reference to an application data object stored by [`Lua::set_app_data()`] of type `T`.
-    pub fn app_data_ref<T: 'static>(&self) -> Option<Ref<T>> {
-        let extra = unsafe { &(*self.extra.get()) };
-        let app_data = extra
-            .app_data
-            .try_borrow()
-            .expect("cannot borrow app data container");
-        let value = app_data.get(&TypeId::of::<T>())?.downcast_ref::<T>()? as *const _;
-        Some(Ref::map(app_data, |_| unsafe { &*value }))
-    }
+	/// Gets a reference to an application data object stored by [`Lua::set_app_data()`] of type `T`.
+	pub fn app_data_ref<T: 'static>(&self) -> Option<Ref<T>> {
+		let extra = unsafe { &(*self.extra.get()) };
+		let app_data = extra
+			.app_data
+			.try_borrow()
+			.expect("cannot borrow app data container");
+		let value = app_data.get(&TypeId::of::<T>())?.downcast_ref::<T>()? as *const _;
+		Some(Ref::map(app_data, |_| unsafe { &*value }))
+	}
 
-    /// Gets a mutable reference to an application data object stored by [`Lua::set_app_data()`] of type `T`.
-    pub fn app_data_mut<T: 'static>(&self) -> Option<RefMut<T>> {
-        let extra = unsafe { &(*self.extra.get()) };
-        let mut app_data = extra
-            .app_data
-            .try_borrow_mut()
-            .expect("cannot mutably borrow app data container");
-        let value = app_data.get_mut(&TypeId::of::<T>())?.downcast_mut::<T>()? as *mut _;
-        Some(RefMut::map(app_data, |_| unsafe { &mut *value }))
-    }
+	/// Gets a mutable reference to an application data object stored by [`Lua::set_app_data()`] of type `T`.
+	pub fn app_data_mut<T: 'static>(&self) -> Option<RefMut<T>> {
+		let extra = unsafe { &(*self.extra.get()) };
+		let mut app_data = extra
+			.app_data
+			.try_borrow_mut()
+			.expect("cannot mutably borrow app data container");
+		let value = app_data.get_mut(&TypeId::of::<T>())?.downcast_mut::<T>()? as *mut _;
+		Some(RefMut::map(app_data, |_| unsafe { &mut *value }))
+	}
 
-    /// Removes an application data of type `T`.
-    pub fn remove_app_data<T: 'static>(&self) -> Option<T> {
-        let extra = unsafe { &mut (*self.extra.get()) };
-        extra
-            .app_data
-            .try_borrow_mut()
-            .expect("cannot mutably borrow app data container")
-            .remove(&TypeId::of::<T>())
-            .and_then(|data| data.downcast().ok().map(|data| *data))
-    }
+	/// Removes an application data of type `T`.
+	pub fn remove_app_data<T: 'static>(&self) -> Option<T> {
+		let extra = unsafe { &mut (*self.extra.get()) };
+		extra
+			.app_data
+			.try_borrow_mut()
+			.expect("cannot mutably borrow app data container")
+			.remove(&TypeId::of::<T>())
+			.and_then(|data| data.downcast().ok().map(|data| *data))
+	}
 
-    // Uses 2 stack spaces, does not call checkstack
-    pub(crate) unsafe fn push_value(&self, value: Value) -> Result<()> {
-        match value {
-            Value::Nil => {
-                ffi::lua_pushnil(self.state);
-            }
+	// Uses 2 stack spaces, does not call checkstack
+	pub(crate) unsafe fn push_value(&self, value: Value) -> Result<()> {
+		match value {
+			Value::Nil => {
+				ffi::lua_pushnil(self.state);
+			}
 
-            Value::Boolean(b) => {
-                ffi::lua_pushboolean(self.state, if b { 1 } else { 0 });
-            }
+			Value::Boolean(b) => {
+				ffi::lua_pushboolean(self.state, if b { 1 } else { 0 });
+			}
 
-            Value::LightUserData(ud) => {
-                ffi::lua_pushlightuserdata(self.state, ud.0);
-            }
+			Value::LightUserData(ud) => {
+				ffi::lua_pushlightuserdata(self.state, ud.0);
+			}
 
-            Value::Integer(i) => {
-                ffi::lua_pushinteger(self.state, i);
-            }
+			Value::Integer(i) => {
+				ffi::lua_pushinteger(self.state, i);
+			}
 
-            Value::Number(n) => {
-                ffi::lua_pushnumber(self.state, n);
-            }
+			Value::Number(n) => {
+				ffi::lua_pushnumber(self.state, n);
+			}
 
-            #[cfg(feature = "luau")]
-            Value::Vector(x, y, z) => {
-                ffi::lua_pushvector(self.state, x, y, z);
-            }
+			#[cfg(feature = "luau")]
+			Value::Vector(x, y, z) => {
+				ffi::lua_pushvector(self.state, x, y, z);
+			}
 
-            Value::String(s) => {
-                self.push_ref(&s.0);
-            }
+			Value::String(s) => {
+				self.push_ref(&s.0);
+			}
 
-            Value::Table(t) => {
-                self.push_ref(&t.0);
-            }
+			Value::Table(t) => {
+				self.push_ref(&t.0);
+			}
 
-            Value::Function(f) => {
-                self.push_ref(&f.0);
-            }
+			Value::Function(f) => {
+				self.push_ref(&f.0);
+			}
 
-            Value::Thread(t) => {
-                self.push_ref(&t.0);
-            }
+			Value::Thread(t) => {
+				self.push_ref(&t.0);
+			}
 
-            Value::UserData(ud) => {
-                self.push_ref(&ud.0);
-            }
+			Value::UserData(ud) => {
+				self.push_ref(&ud.0);
+			}
 
-            Value::Error(err) => {
-                push_gc_userdata(self.state, WrappedFailure::Error(err))?;
-            }
-        }
+			Value::Error(err) => {
+				push_gc_userdata(self.state, WrappedFailure::Error(err))?;
+			}
+		}
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    // Uses 2 stack spaces, does not call checkstack
-    pub(crate) unsafe fn pop_value(&self) -> Value {
-        let state = self.state;
-        match ffi::lua_type(state, -1) {
-            ffi::LUA_TNIL => {
-                ffi::lua_pop(state, 1);
-                Nil
-            }
+	// Uses 2 stack spaces, does not call checkstack
+	pub(crate) unsafe fn pop_value(&self) -> Value {
+		let state = self.state;
+		match ffi::lua_type(state, -1) {
+			ffi::LUA_TNIL => {
+				ffi::lua_pop(state, 1);
+				Nil
+			}
 
-            ffi::LUA_TBOOLEAN => {
-                let b = Value::Boolean(ffi::lua_toboolean(state, -1) != 0);
-                ffi::lua_pop(state, 1);
-                b
-            }
+			ffi::LUA_TBOOLEAN => {
+				let b = Value::Boolean(ffi::lua_toboolean(state, -1) != 0);
+				ffi::lua_pop(state, 1);
+				b
+			}
 
-            ffi::LUA_TLIGHTUSERDATA => {
-                let ud = Value::LightUserData(LightUserData(ffi::lua_touserdata(state, -1)));
-                ffi::lua_pop(state, 1);
-                ud
-            }
+			ffi::LUA_TLIGHTUSERDATA => {
+				let ud = Value::LightUserData(LightUserData(ffi::lua_touserdata(state, -1)));
+				ffi::lua_pop(state, 1);
+				ud
+			}
 
-            ffi::LUA_TNUMBER => {
-                if ffi::lua_isinteger(state, -1) != 0 {
-                    let i = Value::Integer(ffi::lua_tointeger(state, -1));
-                    ffi::lua_pop(state, 1);
-                    i
-                } else {
-                    let n = Value::Number(ffi::lua_tonumber(state, -1));
-                    ffi::lua_pop(state, 1);
-                    n
-                }
-            }
+			ffi::LUA_TNUMBER => {
+				if ffi::lua_isinteger(state, -1) != 0 {
+					let i = Value::Integer(ffi::lua_tointeger(state, -1));
+					ffi::lua_pop(state, 1);
+					i
+				} else {
+					let n = Value::Number(ffi::lua_tonumber(state, -1));
+					ffi::lua_pop(state, 1);
+					n
+				}
+			}
 
-            #[cfg(feature = "luau")]
-            ffi::LUA_TVECTOR => {
-                let v = ffi::lua_tovector(state, -1);
-                mlua_debug_assert!(!v.is_null(), "vector is null");
-                let vec = Value::Vector(*v, *v.add(1), *v.add(2));
-                ffi::lua_pop(state, 1);
-                vec
-            }
+			#[cfg(feature = "luau")]
+			ffi::LUA_TVECTOR => {
+				let v = ffi::lua_tovector(state, -1);
+				mlua_debug_assert!(!v.is_null(), "vector is null");
+				let vec = Value::Vector(*v, *v.add(1), *v.add(2));
+				ffi::lua_pop(state, 1);
+				vec
+			}
 
-            ffi::LUA_TSTRING => Value::String(String(self.pop_ref())),
+			ffi::LUA_TSTRING => Value::String(String(self.pop_ref())),
 
-            ffi::LUA_TTABLE => Value::Table(Table(self.pop_ref())),
+			ffi::LUA_TTABLE => Value::Table(Table(self.pop_ref())),
 
-            ffi::LUA_TFUNCTION => Value::Function(Function(self.pop_ref())),
+			ffi::LUA_TFUNCTION => Value::Function(Function(self.pop_ref())),
 
-            ffi::LUA_TUSERDATA => {
-                // We must prevent interaction with userdata types other than UserData OR a WrappedError.
-                // WrappedPanics are automatically resumed.
-                match get_gc_userdata::<WrappedFailure>(state, -1).as_mut() {
-                    Some(WrappedFailure::Error(err)) => {
-                        let err = err.clone();
-                        ffi::lua_pop(state, 1);
-                        Value::Error(err)
-                    }
-                    Some(WrappedFailure::Panic(panic)) => {
-                        if let Some(panic) = panic.take() {
-                            ffi::lua_pop(state, 1);
-                            resume_unwind(panic);
-                        }
-                        // Previously resumed panic?
-                        ffi::lua_pop(state, 1);
-                        Nil
-                    }
-                    _ => Value::UserData(AnyUserData(self.pop_ref())),
-                }
-            }
+			ffi::LUA_TUSERDATA => {
+				// We must prevent interaction with userdata types other than UserData OR a WrappedError.
+				// WrappedPanics are automatically resumed.
+				match get_gc_userdata::<WrappedFailure>(state, -1).as_mut() {
+					Some(WrappedFailure::Error(err)) => {
+						let err = err.clone();
+						ffi::lua_pop(state, 1);
+						Value::Error(err)
+					}
+					Some(WrappedFailure::Panic(panic)) => {
+						if let Some(panic) = panic.take() {
+							ffi::lua_pop(state, 1);
+							resume_unwind(panic);
+						}
+						// Previously resumed panic?
+						ffi::lua_pop(state, 1);
+						Nil
+					}
+					_ => Value::UserData(AnyUserData(self.pop_ref())),
+				}
+			}
 
-            ffi::LUA_TTHREAD => Value::Thread(Thread(self.pop_ref())),
+			ffi::LUA_TTHREAD => Value::Thread(Thread(self.pop_ref())),
 
-            #[cfg(feature = "luajit")]
-            ffi::LUA_TCDATA => {
-                ffi::lua_pop(state, 1);
-                // TODO: Fix this in a next major release
-                panic!("cdata objects cannot be handled by mlua yet");
-            }
+			#[cfg(feature = "luajit")]
+			ffi::LUA_TCDATA => {
+				ffi::lua_pop(state, 1);
+				// TODO: Fix this in a next major release
+				panic!("cdata objects cannot be handled by mlua yet");
+			}
 
-            _ => mlua_panic!("LUA_TNONE in pop_value"),
-        }
-    }
+			_ => mlua_panic!("LUA_TNONE in pop_value"),
+		}
+	}
 
-    // Pushes a LuaRef value onto the stack, uses 1 stack space, does not call checkstack
-    pub(crate) unsafe fn push_ref(&self, lref: &LuaRef) {
-        assert!(
-            Arc::ptr_eq(&lref.lua.extra, &self.extra),
-            "Lua instance passed Value created from a different main Lua state"
-        );
-        let extra = &*self.extra.get();
-        #[cfg(not(feature = "luau"))]
-        {
-            ffi::lua_pushvalue(extra.ref_thread, lref.index);
-            ffi::lua_xmove(extra.ref_thread, self.state, 1);
-        }
-        #[cfg(feature = "luau")]
-        ffi::lua_xpush(extra.ref_thread, self.state, lref.index);
-    }
+	// Pushes a LuaRef value onto the stack, uses 1 stack space, does not call checkstack
+	pub(crate) unsafe fn push_ref(&self, lref: &LuaRef) {
+		assert!(
+			Arc::ptr_eq(&lref.lua.required().extra, &self.extra),
+			"Lua instance passed Value created from a different main Lua state"
+		);
+		let extra = &*self.extra.get();
+		#[cfg(not(feature = "luau"))]
+		{
+			ffi::lua_pushvalue(extra.ref_thread, lref.index);
+			ffi::lua_xmove(extra.ref_thread, self.state, 1);
+		}
+		#[cfg(feature = "luau")]
+		ffi::lua_xpush(extra.ref_thread, self.state, lref.index);
+	}
 
-    // Pops the topmost element of the stack and stores a reference to it. This pins the object,
-    // preventing garbage collection until the returned `LuaRef` is dropped.
-    //
-    // References are stored in the stack of a specially created auxiliary thread that exists only
-    // to store reference values. This is much faster than storing these in the registry, and also
-    // much more flexible and requires less bookkeeping than storing them directly in the currently
-    // used stack. The implementation is somewhat biased towards the use case of a relatively small
-    // number of short term references being created, and `RegistryKey` being used for long term
-    // references.
-    pub(crate) unsafe fn pop_ref(&self) -> LuaRef {
-        let extra = &mut *self.extra.get();
-        ffi::lua_xmove(self.state, extra.ref_thread, 1);
-        let index = ref_stack_pop(extra);
-        LuaRef { lua: self, index }
-    }
+	// Pops the topmost element of the stack and stores a reference to it. This pins the object,
+	// preventing garbage collection until the returned `LuaRef` is dropped.
+	//
+	// References are stored in the stack of a specially created auxiliary thread that exists only
+	// to store reference values. This is much faster than storing these in the registry, and also
+	// much more flexible and requires less bookkeeping than storing them directly in the currently
+	// used stack. The implementation is somewhat biased towards the use case of a relatively small
+	// number of short term references being created, and `RegistryKey` being used for long term
+	// references.
+	pub(crate) unsafe fn pop_ref(&self) -> LuaRef {
+		let extra = &mut *self.extra.get();
+		ffi::lua_xmove(self.state, extra.ref_thread, 1);
+		let index = ref_stack_pop(extra);
+		LuaRef { lua: LuaWeakRef::new(self), index }
+	}
 
-    pub(crate) fn clone_ref<'lua>(&'lua self, lref: &LuaRef<'lua>) -> LuaRef<'lua> {
-        unsafe {
-            let extra = &mut *self.extra.get();
-            ffi::lua_pushvalue(extra.ref_thread, lref.index);
-            let index = ref_stack_pop(extra);
-            LuaRef { lua: self, index }
-        }
-    }
+	pub(crate) fn clone_ref(&self, lref: &LuaRef) -> LuaRef {
+		unsafe {
+			let extra = &mut *self.extra.get();
+			ffi::lua_pushvalue(extra.ref_thread, lref.index);
+			let index = ref_stack_pop(extra);
+			LuaRef { lua: LuaWeakRef::new(self), index }
+		}
+	}
 
-    pub(crate) fn drop_ref(&self, lref: &LuaRef) {
-        unsafe {
-            let extra = &mut *self.extra.get();
-            ffi::lua_pushnil(extra.ref_thread);
-            ffi::lua_replace(extra.ref_thread, lref.index);
-            extra.ref_free.push(lref.index);
-        }
-    }
+	pub(crate) fn drop_ref(&self, lref: &LuaRef) {
+		unsafe {
+			let extra = &mut *self.extra.get();
+			ffi::lua_pushnil(extra.ref_thread);
+			ffi::lua_replace(extra.ref_thread, lref.index);
+			extra.ref_free.push(lref.index);
+		}
+	}
 
-    /// Executes the function provided on the ref thread
-    #[inline]
-    pub(crate) unsafe fn ref_thread_exec<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce(*mut ffi::lua_State) -> R,
-    {
-        let ref_thread = (*self.extra.get()).ref_thread;
-        f(ref_thread)
-    }
+	/// Executes the function provided on the ref thread
+	#[inline]
+	pub(crate) unsafe fn ref_thread_exec<F, R>(&self, f: F) -> R
+		where
+			F: FnOnce(*mut ffi::lua_State) -> R,
+	{
+		let ref_thread = (*self.extra.get()).ref_thread;
+		f(ref_thread)
+	}
 
-    unsafe fn push_userdata_metatable<T: 'static + UserData>(&self) -> Result<()> {
-        let extra = &mut *self.extra.get();
+	unsafe fn push_userdata_metatable<T: 'static + UserData>(&self) -> Result<()> {
+		let extra = &mut *self.extra.get();
 
-        let type_id = TypeId::of::<T>();
-        if let Some(&table_id) = extra.registered_userdata.get(&type_id) {
-            ffi::lua_rawgeti(self.state, ffi::LUA_REGISTRYINDEX, table_id as Integer);
-            return Ok(());
-        }
+		let type_id = TypeId::of::<T>();
+		if let Some(&table_id) = extra.registered_userdata.get(&type_id) {
+			ffi::lua_rawgeti(self.state, ffi::LUA_REGISTRYINDEX, table_id as Integer);
+			return Ok(());
+		}
 
-        let _sg = StackGuard::new_extra(self.state, 1);
-        check_stack(self.state, 13)?;
+		let _sg = StackGuard::new_extra(self.state, 1);
+		check_stack(self.state, 13)?;
 
-        let mut fields = StaticUserDataFields::default();
-        let mut methods = StaticUserDataMethods::default();
-        T::add_fields(&mut fields);
-        T::add_methods(&mut methods);
+		let mut fields = StaticUserDataFields::default();
+		let mut methods = StaticUserDataMethods::default();
+		T::add_fields(&mut fields);
+		T::add_methods(&mut methods);
 
-        // Prepare metatable, add meta methods first and then meta fields
-        let metatable_nrec = methods.meta_methods.len() + fields.meta_fields.len();
-        #[cfg(feature = "async")]
-        let metatable_nrec = metatable_nrec + methods.async_meta_methods.len();
-        push_table(self.state, 0, metatable_nrec as c_int)?;
-        for (k, m) in methods.meta_methods {
-            self.push_value(Value::Function(self.create_callback(m)?))?;
-            rawset_field(self.state, -2, k.validate()?.name())?;
-        }
-        #[cfg(feature = "async")]
-        for (k, m) in methods.async_meta_methods {
-            self.push_value(Value::Function(self.create_async_callback(m)?))?;
-            rawset_field(self.state, -2, k.validate()?.name())?;
-        }
-        for (k, f) in fields.meta_fields {
-            self.push_value(f(self)?)?;
-            rawset_field(self.state, -2, k.validate()?.name())?;
-        }
-        let metatable_index = ffi::lua_absindex(self.state, -1);
+		// Prepare metatable, add meta methods first and then meta fields
+		let metatable_nrec = methods.meta_methods.len() + fields.meta_fields.len();
+		#[cfg(feature = "async")]
+			let metatable_nrec = metatable_nrec + methods.async_meta_methods.len();
+		push_table(self.state, 0, metatable_nrec as c_int)?;
+		for (k, m) in methods.meta_methods {
+			self.push_value(Value::Function(self.create_callback(m)?))?;
+			rawset_field(self.state, -2, k.validate()?.name())?;
+		}
+		#[cfg(feature = "async")]
+		for (k, m) in methods.async_meta_methods {
+			self.push_value(Value::Function(self.create_async_callback(m)?))?;
+			rawset_field(self.state, -2, k.validate()?.name())?;
+		}
+		for (k, f) in fields.meta_fields {
+			self.push_value(f(self)?)?;
+			rawset_field(self.state, -2, k.validate()?.name())?;
+		}
+		let metatable_index = ffi::lua_absindex(self.state, -1);
 
-        let mut extra_tables_count = 0;
+		let mut extra_tables_count = 0;
 
-        let mut field_getters_index = None;
-        let field_getters_nrec = fields.field_getters.len();
-        if field_getters_nrec > 0 {
-            push_table(self.state, 0, field_getters_nrec as c_int)?;
-            for (k, m) in fields.field_getters {
-                self.push_value(Value::Function(self.create_callback(m)?))?;
-                rawset_field(self.state, -2, &k)?;
-            }
-            field_getters_index = Some(ffi::lua_absindex(self.state, -1));
-            extra_tables_count += 1;
-        }
+		let mut field_getters_index = None;
+		let field_getters_nrec = fields.field_getters.len();
+		if field_getters_nrec > 0 {
+			push_table(self.state, 0, field_getters_nrec as c_int)?;
+			for (k, m) in fields.field_getters {
+				self.push_value(Value::Function(self.create_callback(m)?))?;
+				rawset_field(self.state, -2, &k)?;
+			}
+			field_getters_index = Some(ffi::lua_absindex(self.state, -1));
+			extra_tables_count += 1;
+		}
 
-        let mut field_setters_index = None;
-        let field_setters_nrec = fields.field_setters.len();
-        if field_setters_nrec > 0 {
-            push_table(self.state, 0, field_setters_nrec as c_int)?;
-            for (k, m) in fields.field_setters {
-                self.push_value(Value::Function(self.create_callback(m)?))?;
-                rawset_field(self.state, -2, &k)?;
-            }
-            field_setters_index = Some(ffi::lua_absindex(self.state, -1));
-            extra_tables_count += 1;
-        }
+		let mut field_setters_index = None;
+		let field_setters_nrec = fields.field_setters.len();
+		if field_setters_nrec > 0 {
+			push_table(self.state, 0, field_setters_nrec as c_int)?;
+			for (k, m) in fields.field_setters {
+				self.push_value(Value::Function(self.create_callback(m)?))?;
+				rawset_field(self.state, -2, &k)?;
+			}
+			field_setters_index = Some(ffi::lua_absindex(self.state, -1));
+			extra_tables_count += 1;
+		}
 
-        let mut methods_index = None;
-        let methods_nrec = methods.methods.len();
-        #[cfg(feature = "async")]
-        let methods_nrec = methods_nrec + methods.async_methods.len();
-        if methods_nrec > 0 {
-            push_table(self.state, 0, methods_nrec as c_int)?;
-            for (k, m) in methods.methods {
-                self.push_value(Value::Function(self.create_callback(m)?))?;
-                rawset_field(self.state, -2, &k)?;
-            }
-            #[cfg(feature = "async")]
-            for (k, m) in methods.async_methods {
-                self.push_value(Value::Function(self.create_async_callback(m)?))?;
-                rawset_field(self.state, -2, &k)?;
-            }
-            methods_index = Some(ffi::lua_absindex(self.state, -1));
-            extra_tables_count += 1;
-        }
+		let mut methods_index = None;
+		let methods_nrec = methods.methods.len();
+		#[cfg(feature = "async")]
+			let methods_nrec = methods_nrec + methods.async_methods.len();
+		if methods_nrec > 0 {
+			push_table(self.state, 0, methods_nrec as c_int)?;
+			for (k, m) in methods.methods {
+				self.push_value(Value::Function(self.create_callback(m)?))?;
+				rawset_field(self.state, -2, &k)?;
+			}
+			#[cfg(feature = "async")]
+			for (k, m) in methods.async_methods {
+				self.push_value(Value::Function(self.create_async_callback(m)?))?;
+				rawset_field(self.state, -2, &k)?;
+			}
+			methods_index = Some(ffi::lua_absindex(self.state, -1));
+			extra_tables_count += 1;
+		}
 
-        init_userdata_metatable::<UserDataCell<T>>(
-            self.state,
-            metatable_index,
-            field_getters_index,
-            field_setters_index,
-            methods_index,
-        )?;
+		init_userdata_metatable::<UserDataCell<T>>(
+			self.state,
+			metatable_index,
+			field_getters_index,
+			field_setters_index,
+			methods_index,
+		)?;
 
-        // Pop extra tables to get metatable on top of the stack
-        ffi::lua_pop(self.state, extra_tables_count);
+		// Pop extra tables to get metatable on top of the stack
+		ffi::lua_pop(self.state, extra_tables_count);
 
-        let mt_ptr = ffi::lua_topointer(self.state, -1);
-        ffi::lua_pushvalue(self.state, -1);
-        let id = protect_lua!(self.state, 1, 0, |state| {
+		let mt_ptr = ffi::lua_topointer(self.state, -1);
+		ffi::lua_pushvalue(self.state, -1);
+		let id = protect_lua!(self.state, 1, 0, |state| {
             ffi::luaL_ref(state, ffi::LUA_REGISTRYINDEX)
         })?;
 
-        extra.registered_userdata.insert(type_id, id);
-        extra.registered_userdata_mt.insert(mt_ptr, Some(type_id));
+		extra.registered_userdata.insert(type_id, id);
+		extra.registered_userdata_mt.insert(mt_ptr, Some(type_id));
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    pub(crate) unsafe fn register_userdata_metatable(
-        &self,
-        ptr: *const c_void,
-        type_id: Option<TypeId>,
-    ) {
-        let extra = &mut *self.extra.get();
-        extra.registered_userdata_mt.insert(ptr, type_id);
-    }
+	pub(crate) unsafe fn register_userdata_metatable(
+		&self,
+		ptr: *const c_void,
+		type_id: Option<TypeId>,
+	) {
+		let extra = &mut *self.extra.get();
+		extra.registered_userdata_mt.insert(ptr, type_id);
+	}
 
-    pub(crate) unsafe fn deregister_userdata_metatable(&self, ptr: *const c_void) {
-        (*self.extra.get()).registered_userdata_mt.remove(&ptr);
-    }
+	pub(crate) unsafe fn deregister_userdata_metatable(&self, ptr: *const c_void) {
+		(*self.extra.get()).registered_userdata_mt.remove(&ptr);
+	}
 
-    // Pushes a LuaRef value onto the stack, checking that it's a registered
-    // and not destructed UserData.
-    // Uses 2 stack spaces, does not call checkstack.
-    pub(crate) unsafe fn push_userdata_ref(&self, lref: &LuaRef) -> Result<Option<TypeId>> {
-        self.push_ref(lref);
-        if ffi::lua_getmetatable(self.state, -1) == 0 {
-            return Err(Error::UserDataTypeMismatch);
-        }
-        let mt_ptr = ffi::lua_topointer(self.state, -1);
-        ffi::lua_pop(self.state, 1);
+	// Pushes a LuaRef value onto the stack, checking that it's a registered
+	// and not destructed UserData.
+	// Uses 2 stack spaces, does not call checkstack.
+	pub(crate) unsafe fn push_userdata_ref(&self, lref: &LuaRef) -> Result<Option<TypeId>> {
+		self.push_ref(lref);
+		if ffi::lua_getmetatable(self.state, -1) == 0 {
+			return Err(Error::UserDataTypeMismatch);
+		}
+		let mt_ptr = ffi::lua_topointer(self.state, -1);
+		ffi::lua_pop(self.state, 1);
 
-        let extra = &*self.extra.get();
-        match extra.registered_userdata_mt.get(&mt_ptr) {
-            Some(&type_id) if type_id == Some(TypeId::of::<DestructedUserdataMT>()) => {
-                Err(Error::UserDataDestructed)
-            }
-            Some(&type_id) => Ok(type_id),
-            None => Err(Error::UserDataTypeMismatch),
-        }
-    }
+		let extra = &*self.extra.get();
+		match extra.registered_userdata_mt.get(&mt_ptr) {
+			Some(&type_id) if type_id == Some(TypeId::of::<DestructedUserdataMT>()) => {
+				Err(Error::UserDataDestructed)
+			}
+			Some(&type_id) => Ok(type_id),
+			None => Err(Error::UserDataTypeMismatch),
+		}
+	}
 
-    // Creates a Function out of a Callback containing a 'static Fn. This is safe ONLY because the
-    // Fn is 'static, otherwise it could capture 'lua arguments improperly. Without ATCs, we
-    // cannot easily deal with the "correct" callback type of:
-    //
-    // Box<for<'lua> Fn(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>)>
-    //
-    // So we instead use a caller provided lifetime, which without the 'static requirement would be
-    // unsafe.
-    pub(crate) fn create_callback<'lua>(
-        &'lua self,
-        func: Callback<'lua, 'static>,
-    ) -> Result<Function<'lua>> {
-        unsafe extern "C" fn call_callback(state: *mut ffi::lua_State) -> c_int {
-            let extra = match ffi::lua_type(state, ffi::lua_upvalueindex(1)) {
-                ffi::LUA_TUSERDATA => {
-                    let upvalue = get_userdata::<CallbackUpvalue>(state, ffi::lua_upvalueindex(1));
-                    (*upvalue).extra.get()
-                }
-                _ => ptr::null_mut(),
-            };
-            callback_error_ext(state, extra, |nargs| {
-                let upvalue_idx = ffi::lua_upvalueindex(1);
-                if ffi::lua_type(state, upvalue_idx) == ffi::LUA_TNIL {
-                    return Err(Error::CallbackDestructed);
-                }
-                let upvalue = get_userdata::<CallbackUpvalue>(state, upvalue_idx);
+	// Creates a Function out of a Callback containing a 'static Fn. This is safe ONLY because the
+	// Fn is 'static, otherwise it could capture 'lua arguments improperly. Without ATCs, we
+	// cannot easily deal with the "correct" callback type of:
+	//
+	// Box<for Fn(&Lua, MultiValue) -> Result<MultiValue>)>
+	//
+	// So we instead use a caller provided lifetime, which without the 'static requirement would be
+	// unsafe.
+	pub(crate) fn create_callback(
+		&self,
+		func: Callback<'static>,
+	) -> Result<Function> {
+		unsafe extern "C" fn call_callback(state: *mut ffi::lua_State) -> c_int {
+			let extra = match ffi::lua_type(state, ffi::lua_upvalueindex(1)) {
+				ffi::LUA_TUSERDATA => {
+					let upvalue = get_userdata::<CallbackUpvalue>(state, ffi::lua_upvalueindex(1));
+					(*upvalue).extra.get()
+				}
+				_ => ptr::null_mut(),
+			};
+			callback_error_ext(state, extra, |nargs| {
+				let upvalue_idx = ffi::lua_upvalueindex(1);
+				if ffi::lua_type(state, upvalue_idx) == ffi::LUA_TNIL {
+					return Err(Error::CallbackDestructed);
+				}
+				let upvalue = get_userdata::<CallbackUpvalue>(state, upvalue_idx);
 
-                if nargs < ffi::LUA_MINSTACK {
-                    check_stack(state, ffi::LUA_MINSTACK - nargs)?;
-                }
+				if nargs < ffi::LUA_MINSTACK {
+					check_stack(state, ffi::LUA_MINSTACK - nargs)?;
+				}
 
-                let lua: &Lua = mem::transmute((*extra).inner.as_ref().unwrap());
-                let _guard = StateGuard::new(&mut *lua.0.get(), state);
+				let lua: &Lua = mem::transmute((*extra).inner.as_ref().unwrap());
+				let _guard = StateGuard::new(&mut *lua.0.get(), state);
 
-                let mut args = MultiValue::new_or_cached(lua);
-                args.reserve(nargs as usize);
-                for _ in 0..nargs {
-                    args.push_front(lua.pop_value());
-                }
+				let mut args = MultiValue::new_or_cached(lua);
+				args.reserve(nargs as usize);
+				for _ in 0..nargs {
+					args.push_front(lua.pop_value());
+				}
 
-                let func = &*(*upvalue).data;
-                let mut results = func(lua, args)?;
-                let nresults = results.len() as c_int;
+				let func = &*(*upvalue).data;
+				let mut results = func(lua, args)?;
+				let nresults = results.len() as c_int;
 
-                check_stack(state, nresults)?;
-                for r in results.drain_all() {
-                    lua.push_value(r)?;
-                }
-                lua.cache_multivalue(results);
+				check_stack(state, nresults)?;
+				for r in results.drain_all() {
+					lua.push_value(r)?;
+				}
+				lua.cache_multivalue(results);
 
-                Ok(nresults)
-            })
-        }
+				Ok(nresults)
+			})
+		}
 
-        unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 4)?;
+		unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 4)?;
 
-            let func = mem::transmute(func);
-            let extra = Arc::clone(&self.extra);
-            push_gc_userdata(self.state, CallbackUpvalue { data: func, extra })?;
-            protect_lua!(self.state, 1, 1, fn(state) {
+			let func = mem::transmute(func);
+			let extra = Arc::clone(&self.extra);
+			push_gc_userdata(self.state, CallbackUpvalue { data: func, extra })?;
+			protect_lua!(self.state, 1, 1, fn(state) {
                 ffi::lua_pushcclosure(state, call_callback, 1);
             })?;
 
-            Ok(Function(self.pop_ref()))
-        }
-    }
+			Ok(Function(self.pop_ref()))
+		}
+	}
 
-    #[cfg(feature = "async")]
-    pub(crate) fn create_async_callback<'lua>(
-        &'lua self,
-        func: AsyncCallback<'lua, 'static>,
-    ) -> Result<Function<'lua>> {
-        #[cfg(any(
-            feature = "lua54",
-            feature = "lua53",
-            feature = "lua52",
-            feature = "luau"
-        ))]
-        unsafe {
-            let libs = (*self.extra.get()).libs;
-            if !libs.contains(StdLib::COROUTINE) {
-                self.load_from_std_lib(StdLib::COROUTINE)?;
-            }
-        }
+	#[cfg(feature = "async")]
+	pub(crate) fn create_async_callback(
+		&self,
+		func: AsyncCallback<'static>,
+	) -> Result<Function> {
+		#[cfg(any(
+		feature = "lua54",
+		feature = "lua53",
+		feature = "lua52",
+		feature = "luau"
+		))]
+		unsafe {
+			let libs = (*self.extra.get()).libs;
+			if !libs.contains(StdLib::COROUTINE) {
+				self.load_from_std_lib(StdLib::COROUTINE)?;
+			}
+		}
 
-        unsafe extern "C" fn call_callback(state: *mut ffi::lua_State) -> c_int {
-            let extra = match ffi::lua_type(state, ffi::lua_upvalueindex(1)) {
-                ffi::LUA_TUSERDATA => {
-                    let upvalue =
-                        get_userdata::<AsyncCallbackUpvalue>(state, ffi::lua_upvalueindex(1));
-                    (*upvalue).extra.get()
-                }
-                _ => ptr::null_mut(),
-            };
-            callback_error_ext(state, extra, |nargs| {
-                let upvalue_idx = ffi::lua_upvalueindex(1);
-                if ffi::lua_type(state, upvalue_idx) == ffi::LUA_TNIL {
-                    return Err(Error::CallbackDestructed);
-                }
-                let upvalue = get_userdata::<AsyncCallbackUpvalue>(state, upvalue_idx);
+		unsafe extern "C" fn call_callback(state: *mut ffi::lua_State) -> c_int {
+			let extra = match ffi::lua_type(state, ffi::lua_upvalueindex(1)) {
+				ffi::LUA_TUSERDATA => {
+					let upvalue =
+						get_userdata::<AsyncCallbackUpvalue>(state, ffi::lua_upvalueindex(1));
+					(*upvalue).extra.get()
+				}
+				_ => ptr::null_mut(),
+			};
+			callback_error_ext(state, extra, |nargs| {
+				let upvalue_idx = ffi::lua_upvalueindex(1);
+				if ffi::lua_type(state, upvalue_idx) == ffi::LUA_TNIL {
+					return Err(Error::CallbackDestructed);
+				}
+				let upvalue = get_userdata::<AsyncCallbackUpvalue>(state, upvalue_idx);
 
-                if nargs < ffi::LUA_MINSTACK {
-                    check_stack(state, ffi::LUA_MINSTACK - nargs)?;
-                }
+				if nargs < ffi::LUA_MINSTACK {
+					check_stack(state, ffi::LUA_MINSTACK - nargs)?;
+				}
 
-                let lua: &Lua = mem::transmute((*extra).inner.as_ref().unwrap());
-                let _guard = StateGuard::new(&mut *lua.0.get(), state);
+				let lua: &Lua = mem::transmute((*extra).inner.as_ref().unwrap());
+				let _guard = StateGuard::new(&mut *lua.0.get(), state);
 
-                let mut args = MultiValue::new_or_cached(lua);
-                args.reserve(nargs as usize);
-                for _ in 0..nargs {
-                    args.push_front(lua.pop_value());
-                }
+				let mut args = MultiValue::new_or_cached(lua);
+				args.reserve(nargs as usize);
+				for _ in 0..nargs {
+					args.push_front(lua.pop_value());
+				}
 
-                let func = &*(*upvalue).data;
-                let fut = func(lua, args);
-                let extra = Arc::clone(&(*upvalue).extra);
-                push_gc_userdata(state, AsyncPollUpvalue { data: fut, extra })?;
-                protect_lua!(state, 1, 1, fn(state) {
+				let func = &*(*upvalue).data;
+				let fut = func(lua, args);
+				let extra = Arc::clone(&(*upvalue).extra);
+				push_gc_userdata(state, AsyncPollUpvalue { data: fut, extra })?;
+				protect_lua!(state, 1, 1, fn(state) {
                     ffi::lua_pushcclosure(state, poll_future, 1);
                 })?;
 
-                Ok(1)
-            })
-        }
+				Ok(1)
+			})
+		}
 
-        unsafe extern "C" fn poll_future(state: *mut ffi::lua_State) -> c_int {
-            let extra = match ffi::lua_type(state, ffi::lua_upvalueindex(1)) {
-                ffi::LUA_TUSERDATA => {
-                    let upvalue = get_userdata::<AsyncPollUpvalue>(state, ffi::lua_upvalueindex(1));
-                    (*upvalue).extra.get()
-                }
-                _ => ptr::null_mut(),
-            };
-            callback_error_ext(state, extra, |nargs| {
-                let upvalue_idx = ffi::lua_upvalueindex(1);
-                if ffi::lua_type(state, upvalue_idx) == ffi::LUA_TNIL {
-                    return Err(Error::CallbackDestructed);
-                }
-                let upvalue = get_userdata::<AsyncPollUpvalue>(state, upvalue_idx);
+		unsafe extern "C" fn poll_future(state: *mut ffi::lua_State) -> c_int {
+			let extra = match ffi::lua_type(state, ffi::lua_upvalueindex(1)) {
+				ffi::LUA_TUSERDATA => {
+					let upvalue = get_userdata::<AsyncPollUpvalue>(state, ffi::lua_upvalueindex(1));
+					(*upvalue).extra.get()
+				}
+				_ => ptr::null_mut(),
+			};
+			callback_error_ext(state, extra, |nargs| {
+				let upvalue_idx = ffi::lua_upvalueindex(1);
+				if ffi::lua_type(state, upvalue_idx) == ffi::LUA_TNIL {
+					return Err(Error::CallbackDestructed);
+				}
+				let upvalue = get_userdata::<AsyncPollUpvalue>(state, upvalue_idx);
 
-                if nargs < ffi::LUA_MINSTACK {
-                    check_stack(state, ffi::LUA_MINSTACK - nargs)?;
-                }
+				if nargs < ffi::LUA_MINSTACK {
+					check_stack(state, ffi::LUA_MINSTACK - nargs)?;
+				}
 
-                let lua: &Lua = mem::transmute((*extra).inner.as_ref().unwrap());
-                let _guard = StateGuard::new(&mut *lua.0.get(), state);
+				let lua: &Lua = mem::transmute((*extra).inner.as_ref().unwrap());
+				let _guard = StateGuard::new(&mut *lua.0.get(), state);
 
-                // Try to get an outer poll waker
-                let waker = lua.waker().unwrap_or_else(noop_waker);
-                let mut ctx = Context::from_waker(&waker);
+				// Try to get an outer poll waker
+				let waker = lua.waker().unwrap_or_else(noop_waker);
+				let mut ctx = Context::from_waker(&waker);
 
-                let fut = &mut (*upvalue).data;
-                match fut.as_mut().poll(&mut ctx) {
-                    Poll::Pending => {
-                        check_stack(state, 1)?;
-                        ffi::lua_pushboolean(state, 0);
-                        Ok(1)
-                    }
-                    Poll::Ready(results) => {
-                        let results = results?;
-                        let nresults = results.len() as Integer;
-                        let results = lua.create_sequence_from(results)?;
-                        check_stack(state, 3)?;
-                        ffi::lua_pushboolean(state, 1);
-                        lua.push_value(Value::Table(results))?;
-                        lua.push_value(Value::Integer(nresults))?;
-                        Ok(3)
-                    }
-                }
-            })
-        }
+				let fut = &mut (*upvalue).data;
+				match fut.as_mut().poll(&mut ctx) {
+					Poll::Pending => {
+						check_stack(state, 1)?;
+						ffi::lua_pushboolean(state, 0);
+						Ok(1)
+					}
+					Poll::Ready(results) => {
+						let results = results?;
+						let nresults = results.len() as Integer;
+						let results = lua.create_sequence_from(results)?;
+						check_stack(state, 3)?;
+						ffi::lua_pushboolean(state, 1);
+						lua.push_value(Value::Table(results))?;
+						lua.push_value(Value::Integer(nresults))?;
+						Ok(3)
+					}
+				}
+			})
+		}
 
-        let get_poll = unsafe {
-            let _sg = StackGuard::new(self.state);
-            check_stack(self.state, 4)?;
+		let get_poll = unsafe {
+			let _sg = StackGuard::new(self.state);
+			check_stack(self.state, 4)?;
 
-            let func = mem::transmute(func);
-            let extra = Arc::clone(&self.extra);
-            push_gc_userdata(self.state, AsyncCallbackUpvalue { data: func, extra })?;
-            protect_lua!(self.state, 1, 1, fn(state) {
+			let func = mem::transmute(func);
+			let extra = Arc::clone(&self.extra);
+			push_gc_userdata(self.state, AsyncCallbackUpvalue { data: func, extra })?;
+			protect_lua!(self.state, 1, 1, fn(state) {
                 ffi::lua_pushcclosure(state, call_callback, 1);
             })?;
 
-            Function(self.pop_ref())
-        };
+			Function(self.pop_ref())
+		};
 
-        unsafe extern "C" fn unpack(state: *mut ffi::lua_State) -> c_int {
-            let len = ffi::lua_tointeger(state, 2);
-            ffi::luaL_checkstack(state, len as c_int, ptr::null());
-            for i in 1..=len {
-                ffi::lua_rawgeti(state, 1, i);
-            }
-            len as c_int
-        }
+		unsafe extern "C" fn unpack(state: *mut ffi::lua_State) -> c_int {
+			let len = ffi::lua_tointeger(state, 2);
+			ffi::luaL_checkstack(state, len as c_int, ptr::null());
+			for i in 1..=len {
+				ffi::lua_rawgeti(state, 1, i);
+			}
+			len as c_int
+		}
 
-        let coroutine = self.globals().get::<_, Table>("coroutine")?;
+		let coroutine = self.globals().get::<_, Table>("coroutine")?;
 
-        let env = self.create_table_with_capacity(0, 4)?;
-        env.set("get_poll", get_poll)?;
-        env.set("yield", coroutine.get::<_, Function>("yield")?)?;
-        unsafe {
-            env.set("unpack", self.create_c_function(unpack)?)?;
-        }
-        env.set("pending", {
-            LightUserData(&ASYNC_POLL_PENDING as *const u8 as *mut c_void)
-        })?;
+		let env = self.create_table_with_capacity(0, 4)?;
+		env.set("get_poll", get_poll)?;
+		env.set("yield", coroutine.get::<_, Function>("yield")?)?;
+		unsafe {
+			env.set("unpack", self.create_c_function(unpack)?)?;
+		}
+		env.set("pending", {
+			LightUserData(&ASYNC_POLL_PENDING as *const u8 as *mut c_void)
+		})?;
 
-        // We set `poll` variable in the env table to be able to destroy upvalues
-        self.load(
-            r#"
+		// We set `poll` variable in the env table to be able to destroy upvalues
+		self.load(
+			r#"
             poll = get_poll(...)
             local poll, pending, yield, unpack = poll, pending, yield, unpack
             while true do
@@ -2740,429 +2759,429 @@ impl Lua {
                 yield(pending)
             end
             "#,
-        )
-        .set_name("_mlua_async_poll")?
-        .set_environment(env)?
-        .into_function()
-    }
+		)
+			.set_name("_mlua_async_poll")?
+			.set_environment(env)?
+			.into_function()
+	}
 
-    #[cfg(feature = "async")]
-    #[inline]
-    pub(crate) unsafe fn waker(&self) -> Option<Waker> {
-        let extra = &*self.extra.get();
-        (*get_userdata::<Option<Waker>>(extra.ref_thread, extra.ref_waker_idx)).clone()
-    }
+	#[cfg(feature = "async")]
+	#[inline]
+	pub(crate) unsafe fn waker(&self) -> Option<Waker> {
+		let extra = &*self.extra.get();
+		(*get_userdata::<Option<Waker>>(extra.ref_thread, extra.ref_waker_idx)).clone()
+	}
 
-    #[cfg(feature = "async")]
-    #[inline]
-    pub(crate) unsafe fn set_waker(&self, waker: Option<Waker>) -> Option<Waker> {
-        let extra = &*self.extra.get();
-        let waker_slot = &mut *get_userdata::<Option<Waker>>(extra.ref_thread, extra.ref_waker_idx);
-        match waker {
-            Some(waker) => waker_slot.replace(waker),
-            None => waker_slot.take(),
-        }
-    }
+	#[cfg(feature = "async")]
+	#[inline]
+	pub(crate) unsafe fn set_waker(&self, waker: Option<Waker>) -> Option<Waker> {
+		let extra = &*self.extra.get();
+		let waker_slot = &mut *get_userdata::<Option<Waker>>(extra.ref_thread, extra.ref_waker_idx);
+		match waker {
+			Some(waker) => waker_slot.replace(waker),
+			None => waker_slot.take(),
+		}
+	}
 
-    pub(crate) unsafe fn make_userdata<T>(&self, data: UserDataCell<T>) -> Result<AnyUserData>
-    where
-        T: 'static + UserData,
-    {
-        let _sg = StackGuard::new(self.state);
-        check_stack(self.state, 3)?;
+	pub(crate) unsafe fn make_userdata<T>(&self, data: UserDataCell<T>) -> Result<AnyUserData>
+		where
+			T: 'static + UserData,
+	{
+		let _sg = StackGuard::new(self.state);
+		check_stack(self.state, 3)?;
 
-        // We push metatable first to ensure having correct metatable with `__gc` method
-        ffi::lua_pushnil(self.state);
-        self.push_userdata_metatable::<T>()?;
-        #[cfg(not(feature = "lua54"))]
-        push_userdata(self.state, data)?;
-        #[cfg(feature = "lua54")]
-        push_userdata_uv(self.state, data, USER_VALUE_MAXSLOT as c_int)?;
-        ffi::lua_replace(self.state, -3);
-        ffi::lua_setmetatable(self.state, -2);
+		// We push metatable first to ensure having correct metatable with `__gc` method
+		ffi::lua_pushnil(self.state);
+		self.push_userdata_metatable::<T>()?;
+		#[cfg(not(feature = "lua54"))]
+		push_userdata(self.state, data)?;
+		#[cfg(feature = "lua54")]
+		push_userdata_uv(self.state, data, USER_VALUE_MAXSLOT as c_int)?;
+		ffi::lua_replace(self.state, -3);
+		ffi::lua_setmetatable(self.state, -2);
 
-        // Set empty environment for Lua 5.1
-        #[cfg(any(feature = "lua51", feature = "luajit"))]
-        protect_lua!(self.state, 1, 1, fn(state) {
+		// Set empty environment for Lua 5.1
+		#[cfg(any(feature = "lua51", feature = "luajit"))]
+		protect_lua!(self.state, 1, 1, fn(state) {
             ffi::lua_newtable(state);
             ffi::lua_setuservalue(state, -2);
         })?;
 
-        Ok(AnyUserData(self.pop_ref()))
-    }
+		Ok(AnyUserData(self.pop_ref()))
+	}
 
-    #[cfg(not(feature = "luau"))]
-    fn disable_c_modules(&self) -> Result<()> {
-        let package: Table = self.globals().get("package")?;
+	#[cfg(not(feature = "luau"))]
+	fn disable_c_modules(&self) -> Result<()> {
+		let package: Table = self.globals().get("package")?;
 
-        package.set(
-            "loadlib",
-            self.create_function(|_, ()| -> Result<()> {
-                Err(Error::SafetyError(
-                    "package.loadlib is disabled in safe mode".to_string(),
-                ))
-            })?,
-        )?;
+		package.set(
+			"loadlib",
+			self.create_function(|_, ()| -> Result<()> {
+				Err(Error::SafetyError(
+					"package.loadlib is disabled in safe mode".to_string(),
+				))
+			})?,
+		)?;
 
-        #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
-        let searchers: Table = package.get("searchers")?;
-        #[cfg(any(feature = "lua51", feature = "luajit"))]
-        let searchers: Table = package.get("loaders")?;
+		#[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
+			let searchers: Table = package.get("searchers")?;
+		#[cfg(any(feature = "lua51", feature = "luajit"))]
+			let searchers: Table = package.get("loaders")?;
 
-        let loader = self.create_function(|_, ()| Ok("\n\tcan't load C modules in safe mode"))?;
+		let loader = self.create_function(|_, ()| Ok("\n\tcan't load C modules in safe mode"))?;
 
-        // The third and fourth searchers looks for a loader as a C library
-        searchers.raw_set(3, loader.clone())?;
-        searchers.raw_remove(4)?;
+		// The third and fourth searchers looks for a loader as a C library
+		searchers.raw_set(3, loader.clone())?;
+		searchers.raw_remove(4)?;
 
-        Ok(())
-    }
+		Ok(())
+	}
 
-    pub(crate) unsafe fn make_from_ptr(state: *mut ffi::lua_State) -> Option<Self> {
-        let _sg = StackGuard::new(state);
-        assert_stack(state, 1);
-        let extra = extra_data(state)?;
-        let inner = &*(*extra.get()).inner.as_ref().unwrap();
-        Some(Lua(Arc::clone(inner)))
-    }
+	pub(crate) unsafe fn make_from_ptr(state: *mut ffi::lua_State) -> Option<Self> {
+		let _sg = StackGuard::new(state);
+		assert_stack(state, 1);
+		let extra = extra_data(state)?;
+		let inner = &*(*extra.get()).inner.as_ref().unwrap();
+		Some(Lua(Arc::clone(inner)))
+	}
 
-    #[inline]
-    pub(crate) fn new_or_cached_multivalue(&self) -> MultiValue {
-        unsafe {
-            let extra = &mut *self.extra.get();
-            extra.multivalue_cache.pop().unwrap_or_default()
-        }
-    }
+	#[inline]
+	pub(crate) fn new_or_cached_multivalue(&self) -> MultiValue {
+		unsafe {
+			let extra = &mut *self.extra.get();
+			extra.multivalue_cache.pop().unwrap_or_default()
+		}
+	}
 
-    #[inline]
-    pub(crate) fn cache_multivalue(&self, mut multivalue: MultiValue) {
-        unsafe {
-            let extra = &mut *self.extra.get();
-            if extra.multivalue_cache.len() < MULTIVALUE_CACHE_SIZE {
-                multivalue.clear();
-                extra.multivalue_cache.push(mem::transmute(multivalue));
-            }
-        }
-    }
+	#[inline]
+	pub(crate) fn cache_multivalue(&self, mut multivalue: MultiValue) {
+		unsafe {
+			let extra = &mut *self.extra.get();
+			if extra.multivalue_cache.len() < MULTIVALUE_CACHE_SIZE {
+				multivalue.clear();
+				extra.multivalue_cache.push(mem::transmute(multivalue));
+			}
+		}
+	}
 }
 
 struct StateGuard<'a>(&'a mut LuaInner, *mut ffi::lua_State);
 
 impl<'a> StateGuard<'a> {
-    fn new(inner: &'a mut LuaInner, mut state: *mut ffi::lua_State) -> Self {
-        mem::swap(&mut (*inner).state, &mut state);
-        Self(inner, state)
-    }
+	fn new(inner: &'a mut LuaInner, mut state: *mut ffi::lua_State) -> Self {
+		mem::swap(&mut (*inner).state, &mut state);
+		Self(inner, state)
+	}
 }
 
 impl<'a> Drop for StateGuard<'a> {
-    fn drop(&mut self) {
-        mem::swap(&mut (*self.0).state, &mut self.1);
-    }
+	fn drop(&mut self) {
+		mem::swap(&mut (*self.0).state, &mut self.1);
+	}
 }
 
 #[cfg(feature = "luau")]
 unsafe fn extra_data(state: *mut ffi::lua_State) -> Option<Arc<UnsafeCell<ExtraData>>> {
-    let extra_ptr = (*ffi::lua_callbacks(state)).userdata as *mut Arc<UnsafeCell<ExtraData>>;
-    if extra_ptr.is_null() {
-        return None;
-    }
-    Some(Arc::clone(&*extra_ptr))
+	let extra_ptr = (*ffi::lua_callbacks(state)).userdata as *mut Arc<UnsafeCell<ExtraData>>;
+	if extra_ptr.is_null() {
+		return None;
+	}
+	Some(Arc::clone(&*extra_ptr))
 }
 
 #[cfg(not(feature = "luau"))]
 unsafe fn extra_data(state: *mut ffi::lua_State) -> Option<Arc<UnsafeCell<ExtraData>>> {
-    let extra_key = &EXTRA_REGISTRY_KEY as *const u8 as *const c_void;
-    if ffi::lua_rawgetp(state, ffi::LUA_REGISTRYINDEX, extra_key) != ffi::LUA_TUSERDATA {
-        return None;
-    }
-    let extra_ptr = ffi::lua_touserdata(state, -1) as *mut Arc<UnsafeCell<ExtraData>>;
-    let extra = Arc::clone(&*extra_ptr);
-    ffi::lua_pop(state, 1);
-    Some(extra)
+	let extra_key = &EXTRA_REGISTRY_KEY as *const u8 as *const c_void;
+	if ffi::lua_rawgetp(state, ffi::LUA_REGISTRYINDEX, extra_key) != ffi::LUA_TUSERDATA {
+		return None;
+	}
+	let extra_ptr = ffi::lua_touserdata(state, -1) as *mut Arc<UnsafeCell<ExtraData>>;
+	let extra = Arc::clone(&*extra_ptr);
+	ffi::lua_pop(state, 1);
+	Some(extra)
 }
 
 // Creates required entries in the metatable cache (see `util::METATABLE_CACHE`)
 pub(crate) fn init_metatable_cache(cache: &mut FxHashMap<TypeId, u8>) {
-    cache.insert(TypeId::of::<Arc<UnsafeCell<ExtraData>>>(), 0);
-    cache.insert(TypeId::of::<Callback>(), 0);
-    cache.insert(TypeId::of::<CallbackUpvalue>(), 0);
+	cache.insert(TypeId::of::<Arc<UnsafeCell<ExtraData>>>(), 0);
+	cache.insert(TypeId::of::<Callback>(), 0);
+	cache.insert(TypeId::of::<CallbackUpvalue>(), 0);
 
-    #[cfg(feature = "async")]
-    {
-        cache.insert(TypeId::of::<AsyncCallback>(), 0);
-        cache.insert(TypeId::of::<AsyncCallbackUpvalue>(), 0);
-        cache.insert(TypeId::of::<AsyncPollUpvalue>(), 0);
-        cache.insert(TypeId::of::<Option<Waker>>(), 0);
-    }
+	#[cfg(feature = "async")]
+	{
+		cache.insert(TypeId::of::<AsyncCallback>(), 0);
+		cache.insert(TypeId::of::<AsyncCallbackUpvalue>(), 0);
+		cache.insert(TypeId::of::<AsyncPollUpvalue>(), 0);
+		cache.insert(TypeId::of::<Option<Waker>>(), 0);
+	}
 }
 
 // An optimized version of `callback_error` that does not allocate `WrappedFailure` userdata
 // and instead reuses unsed and cached values from previous calls (or allocates new).
 unsafe fn callback_error_ext<F, R>(state: *mut ffi::lua_State, extra: *mut ExtraData, f: F) -> R
-where
-    F: FnOnce(c_int) -> Result<R>,
+	where
+		F: FnOnce(c_int) -> Result<R>,
 {
-    if extra.is_null() {
-        return callback_error(state, f);
-    }
-    let extra = &mut *extra;
+	if extra.is_null() {
+		return callback_error(state, f);
+	}
+	let extra = &mut *extra;
 
-    let nargs = ffi::lua_gettop(state);
+	let nargs = ffi::lua_gettop(state);
 
-    enum PreallocatedFailure {
-        New(*mut WrappedFailure),
-        Cached(i32),
-    }
+	enum PreallocatedFailure {
+		New(*mut WrappedFailure),
+		Cached(i32),
+	}
 
-    // We cannot shadow Rust errors with Lua ones, so we need to obtain pre-allocated memory
-    // to store a wrapped failure (error or panic) *before* we proceed.
-    let prealloc_failure = match extra.wrapped_failures_cache.pop() {
-        Some(index) => PreallocatedFailure::Cached(index),
-        None => {
-            // We need 2 extra stack spaces to store userdata and error/panic metatable.
-            let extra_stack = if nargs < 2 { 2 - nargs } else { 1 };
-            ffi::luaL_checkstack(
-                state,
-                extra_stack,
-                cstr!("not enough stack space for callback error handling"),
-            );
-            let ud = WrappedFailure::new_userdata(state);
-            ffi::lua_rotate(state, 1, 1);
-            PreallocatedFailure::New(ud)
-        }
-    };
+	// We cannot shadow Rust errors with Lua ones, so we need to obtain pre-allocated memory
+	// to store a wrapped failure (error or panic) *before* we proceed.
+	let prealloc_failure = match extra.wrapped_failures_cache.pop() {
+		Some(index) => PreallocatedFailure::Cached(index),
+		None => {
+			// We need 2 extra stack spaces to store userdata and error/panic metatable.
+			let extra_stack = if nargs < 2 { 2 - nargs } else { 1 };
+			ffi::luaL_checkstack(
+				state,
+				extra_stack,
+				cstr!("not enough stack space for callback error handling"),
+			);
+			let ud = WrappedFailure::new_userdata(state);
+			ffi::lua_rotate(state, 1, 1);
+			PreallocatedFailure::New(ud)
+		}
+	};
 
-    let mut get_wrapped_failure = || match prealloc_failure {
-        PreallocatedFailure::New(ud) => {
-            ffi::lua_settop(state, 1);
-            ud
-        }
-        PreallocatedFailure::Cached(index) => {
-            ffi::lua_settop(state, 0);
-            ffi::lua_pushvalue(extra.ref_thread, index);
-            ffi::lua_xmove(extra.ref_thread, state, 1);
-            ffi::lua_pushnil(extra.ref_thread);
-            ffi::lua_replace(extra.ref_thread, index);
-            extra.ref_free.push(index);
-            ffi::lua_touserdata(state, -1) as *mut WrappedFailure
-        }
-    };
+	let mut get_wrapped_failure = || match prealloc_failure {
+		PreallocatedFailure::New(ud) => {
+			ffi::lua_settop(state, 1);
+			ud
+		}
+		PreallocatedFailure::Cached(index) => {
+			ffi::lua_settop(state, 0);
+			ffi::lua_pushvalue(extra.ref_thread, index);
+			ffi::lua_xmove(extra.ref_thread, state, 1);
+			ffi::lua_pushnil(extra.ref_thread);
+			ffi::lua_replace(extra.ref_thread, index);
+			extra.ref_free.push(index);
+			ffi::lua_touserdata(state, -1) as *mut WrappedFailure
+		}
+	};
 
-    match catch_unwind(AssertUnwindSafe(|| f(nargs))) {
-        Ok(Ok(r)) => {
-            // Return unused WrappedFailure to the cache
-            match prealloc_failure {
-                PreallocatedFailure::New(_)
-                    if extra.wrapped_failures_cache.len() < WRAPPED_FAILURES_CACHE_SIZE =>
-                {
-                    ffi::lua_rotate(state, 1, -1);
-                    ffi::lua_xmove(state, extra.ref_thread, 1);
-                    let index = ref_stack_pop(extra);
-                    extra.wrapped_failures_cache.push(index);
-                }
-                PreallocatedFailure::New(_) => {
-                    ffi::lua_remove(state, 1);
-                }
-                PreallocatedFailure::Cached(index)
-                    if extra.wrapped_failures_cache.len() < WRAPPED_FAILURES_CACHE_SIZE =>
-                {
-                    extra.wrapped_failures_cache.push(index);
-                }
-                PreallocatedFailure::Cached(index) => {
-                    ffi::lua_pushnil(extra.ref_thread);
-                    ffi::lua_replace(extra.ref_thread, index);
-                    extra.ref_free.push(index);
-                }
-            }
-            r
-        }
-        Ok(Err(err)) => {
-            let wrapped_error = get_wrapped_failure();
+	match catch_unwind(AssertUnwindSafe(|| f(nargs))) {
+		Ok(Ok(r)) => {
+			// Return unused WrappedFailure to the cache
+			match prealloc_failure {
+				PreallocatedFailure::New(_)
+				if extra.wrapped_failures_cache.len() < WRAPPED_FAILURES_CACHE_SIZE =>
+					{
+						ffi::lua_rotate(state, 1, -1);
+						ffi::lua_xmove(state, extra.ref_thread, 1);
+						let index = ref_stack_pop(extra);
+						extra.wrapped_failures_cache.push(index);
+					}
+				PreallocatedFailure::New(_) => {
+					ffi::lua_remove(state, 1);
+				}
+				PreallocatedFailure::Cached(index)
+				if extra.wrapped_failures_cache.len() < WRAPPED_FAILURES_CACHE_SIZE =>
+					{
+						extra.wrapped_failures_cache.push(index);
+					}
+				PreallocatedFailure::Cached(index) => {
+					ffi::lua_pushnil(extra.ref_thread);
+					ffi::lua_replace(extra.ref_thread, index);
+					extra.ref_free.push(index);
+				}
+			}
+			r
+		}
+		Ok(Err(err)) => {
+			let wrapped_error = get_wrapped_failure();
 
-            // Build `CallbackError` with traceback
-            let traceback = if ffi::lua_checkstack(state, ffi::LUA_TRACEBACK_STACK) != 0 {
-                ffi::luaL_traceback(state, state, ptr::null(), 0);
-                let traceback = util::to_string(state, -1);
-                ffi::lua_pop(state, 1);
-                traceback
-            } else {
-                "<not enough stack space for traceback>".to_string()
-            };
-            let cause = Arc::new(err);
-            ptr::write(
-                wrapped_error,
-                WrappedFailure::Error(Error::CallbackError { traceback, cause }),
-            );
-            get_gc_metatable::<WrappedFailure>(state);
-            ffi::lua_setmetatable(state, -2);
+			// Build `CallbackError` with traceback
+			let traceback = if ffi::lua_checkstack(state, ffi::LUA_TRACEBACK_STACK) != 0 {
+				ffi::luaL_traceback(state, state, ptr::null(), 0);
+				let traceback = util::to_string(state, -1);
+				ffi::lua_pop(state, 1);
+				traceback
+			} else {
+				"<not enough stack space for traceback>".to_string()
+			};
+			let cause = Arc::new(err);
+			ptr::write(
+				wrapped_error,
+				WrappedFailure::Error(Error::CallbackError { traceback, cause }),
+			);
+			get_gc_metatable::<WrappedFailure>(state);
+			ffi::lua_setmetatable(state, -2);
 
-            ffi::lua_error(state)
-        }
-        Err(p) => {
-            let wrapped_panic = get_wrapped_failure();
-            ptr::write(wrapped_panic, WrappedFailure::Panic(Some(p)));
-            get_gc_metatable::<WrappedFailure>(state);
-            ffi::lua_setmetatable(state, -2);
-            ffi::lua_error(state)
-        }
-    }
+			ffi::lua_error(state)
+		}
+		Err(p) => {
+			let wrapped_panic = get_wrapped_failure();
+			ptr::write(wrapped_panic, WrappedFailure::Panic(Some(p)));
+			get_gc_metatable::<WrappedFailure>(state);
+			ffi::lua_setmetatable(state, -2);
+			ffi::lua_error(state)
+		}
+	}
 }
 
 // Uses 3 stack spaces
 unsafe fn load_from_std_lib(state: *mut ffi::lua_State, libs: StdLib) -> Result<()> {
-    #[inline(always)]
-    pub unsafe fn requiref<S: AsRef<[u8]> + ?Sized>(
-        state: *mut ffi::lua_State,
-        modname: &S,
-        openf: ffi::lua_CFunction,
-        glb: c_int,
-    ) -> Result<()> {
-        let modname = mlua_expect!(CString::new(modname.as_ref()), "modname contains nil byte");
-        protect_lua!(state, 0, 1, |state| {
+	#[inline(always)]
+	pub unsafe fn requiref<S: AsRef<[u8]> + ?Sized>(
+		state: *mut ffi::lua_State,
+		modname: &S,
+		openf: ffi::lua_CFunction,
+		glb: c_int,
+	) -> Result<()> {
+		let modname = mlua_expect!(CString::new(modname.as_ref()), "modname contains nil byte");
+		protect_lua!(state, 0, 1, |state| {
             ffi::luaL_requiref(state, modname.as_ptr() as *const c_char, openf, glb)
         })
-    }
+	}
 
-    #[cfg(feature = "luajit")]
-    struct GcGuard(*mut ffi::lua_State);
+	#[cfg(feature = "luajit")]
+	struct GcGuard(*mut ffi::lua_State);
 
-    #[cfg(feature = "luajit")]
-    impl GcGuard {
-        fn new(state: *mut ffi::lua_State) -> Self {
-            // Stop collector during library initialization
-            unsafe { ffi::lua_gc(state, ffi::LUA_GCSTOP, 0) };
-            GcGuard(state)
-        }
-    }
+	#[cfg(feature = "luajit")]
+	impl GcGuard {
+		fn new(state: *mut ffi::lua_State) -> Self {
+			// Stop collector during library initialization
+			unsafe { ffi::lua_gc(state, ffi::LUA_GCSTOP, 0) };
+			GcGuard(state)
+		}
+	}
 
-    #[cfg(feature = "luajit")]
-    impl Drop for GcGuard {
-        fn drop(&mut self) {
-            unsafe { ffi::lua_gc(self.0, ffi::LUA_GCRESTART, -1) };
-        }
-    }
+	#[cfg(feature = "luajit")]
+	impl Drop for GcGuard {
+		fn drop(&mut self) {
+			unsafe { ffi::lua_gc(self.0, ffi::LUA_GCRESTART, -1) };
+		}
+	}
 
-    // Stop collector during library initialization
-    #[cfg(feature = "luajit")]
-    let _gc_guard = GcGuard::new(state);
+	// Stop collector during library initialization
+	#[cfg(feature = "luajit")]
+		let _gc_guard = GcGuard::new(state);
 
-    #[cfg(any(
-        feature = "lua54",
-        feature = "lua53",
-        feature = "lua52",
-        feature = "luau"
-    ))]
-    {
-        if libs.contains(StdLib::COROUTINE) {
-            requiref(state, ffi::LUA_COLIBNAME, ffi::luaopen_coroutine, 1)?;
-            ffi::lua_pop(state, 1);
-        }
-    }
+	#[cfg(any(
+	feature = "lua54",
+	feature = "lua53",
+	feature = "lua52",
+	feature = "luau"
+	))]
+	{
+		if libs.contains(StdLib::COROUTINE) {
+			requiref(state, ffi::LUA_COLIBNAME, ffi::luaopen_coroutine, 1)?;
+			ffi::lua_pop(state, 1);
+		}
+	}
 
-    if libs.contains(StdLib::TABLE) {
-        requiref(state, ffi::LUA_TABLIBNAME, ffi::luaopen_table, 1)?;
-        ffi::lua_pop(state, 1);
-    }
+	if libs.contains(StdLib::TABLE) {
+		requiref(state, ffi::LUA_TABLIBNAME, ffi::luaopen_table, 1)?;
+		ffi::lua_pop(state, 1);
+	}
 
-    #[cfg(not(feature = "luau"))]
-    if libs.contains(StdLib::IO) {
-        requiref(state, ffi::LUA_IOLIBNAME, ffi::luaopen_io, 1)?;
-        ffi::lua_pop(state, 1);
-    }
+	#[cfg(not(feature = "luau"))]
+	if libs.contains(StdLib::IO) {
+		requiref(state, ffi::LUA_IOLIBNAME, ffi::luaopen_io, 1)?;
+		ffi::lua_pop(state, 1);
+	}
 
-    if libs.contains(StdLib::OS) {
-        requiref(state, ffi::LUA_OSLIBNAME, ffi::luaopen_os, 1)?;
-        ffi::lua_pop(state, 1);
-    }
+	if libs.contains(StdLib::OS) {
+		requiref(state, ffi::LUA_OSLIBNAME, ffi::luaopen_os, 1)?;
+		ffi::lua_pop(state, 1);
+	}
 
-    if libs.contains(StdLib::STRING) {
-        requiref(state, ffi::LUA_STRLIBNAME, ffi::luaopen_string, 1)?;
-        ffi::lua_pop(state, 1);
-    }
+	if libs.contains(StdLib::STRING) {
+		requiref(state, ffi::LUA_STRLIBNAME, ffi::luaopen_string, 1)?;
+		ffi::lua_pop(state, 1);
+	}
 
-    #[cfg(any(feature = "lua54", feature = "lua53", feature = "luau"))]
-    {
-        if libs.contains(StdLib::UTF8) {
-            requiref(state, ffi::LUA_UTF8LIBNAME, ffi::luaopen_utf8, 1)?;
-            ffi::lua_pop(state, 1);
-        }
-    }
+	#[cfg(any(feature = "lua54", feature = "lua53", feature = "luau"))]
+	{
+		if libs.contains(StdLib::UTF8) {
+			requiref(state, ffi::LUA_UTF8LIBNAME, ffi::luaopen_utf8, 1)?;
+			ffi::lua_pop(state, 1);
+		}
+	}
 
-    #[cfg(any(feature = "lua52", feature = "luau"))]
-    {
-        if libs.contains(StdLib::BIT) {
-            requiref(state, ffi::LUA_BITLIBNAME, ffi::luaopen_bit32, 1)?;
-            ffi::lua_pop(state, 1);
-        }
-    }
+	#[cfg(any(feature = "lua52", feature = "luau"))]
+	{
+		if libs.contains(StdLib::BIT) {
+			requiref(state, ffi::LUA_BITLIBNAME, ffi::luaopen_bit32, 1)?;
+			ffi::lua_pop(state, 1);
+		}
+	}
 
-    #[cfg(feature = "luajit")]
-    {
-        if libs.contains(StdLib::BIT) {
-            requiref(state, ffi::LUA_BITLIBNAME, ffi::luaopen_bit, 1)?;
-            ffi::lua_pop(state, 1);
-        }
-    }
+	#[cfg(feature = "luajit")]
+	{
+		if libs.contains(StdLib::BIT) {
+			requiref(state, ffi::LUA_BITLIBNAME, ffi::luaopen_bit, 1)?;
+			ffi::lua_pop(state, 1);
+		}
+	}
 
-    if libs.contains(StdLib::MATH) {
-        requiref(state, ffi::LUA_MATHLIBNAME, ffi::luaopen_math, 1)?;
-        ffi::lua_pop(state, 1);
-    }
+	if libs.contains(StdLib::MATH) {
+		requiref(state, ffi::LUA_MATHLIBNAME, ffi::luaopen_math, 1)?;
+		ffi::lua_pop(state, 1);
+	}
 
-    if libs.contains(StdLib::DEBUG) {
-        requiref(state, ffi::LUA_DBLIBNAME, ffi::luaopen_debug, 1)?;
-        ffi::lua_pop(state, 1);
-    }
+	if libs.contains(StdLib::DEBUG) {
+		requiref(state, ffi::LUA_DBLIBNAME, ffi::luaopen_debug, 1)?;
+		ffi::lua_pop(state, 1);
+	}
 
-    #[cfg(not(feature = "luau"))]
-    if libs.contains(StdLib::PACKAGE) {
-        requiref(state, ffi::LUA_LOADLIBNAME, ffi::luaopen_package, 1)?;
-        ffi::lua_pop(state, 1);
-    }
+	#[cfg(not(feature = "luau"))]
+	if libs.contains(StdLib::PACKAGE) {
+		requiref(state, ffi::LUA_LOADLIBNAME, ffi::luaopen_package, 1)?;
+		ffi::lua_pop(state, 1);
+	}
 
-    #[cfg(feature = "luajit")]
-    {
-        if libs.contains(StdLib::JIT) {
-            requiref(state, ffi::LUA_JITLIBNAME, ffi::luaopen_jit, 1)?;
-            ffi::lua_pop(state, 1);
-        }
+	#[cfg(feature = "luajit")]
+	{
+		if libs.contains(StdLib::JIT) {
+			requiref(state, ffi::LUA_JITLIBNAME, ffi::luaopen_jit, 1)?;
+			ffi::lua_pop(state, 1);
+		}
 
-        if libs.contains(StdLib::FFI) {
-            requiref(state, ffi::LUA_FFILIBNAME, ffi::luaopen_ffi, 1)?;
-            ffi::lua_pop(state, 1);
-        }
-    }
+		if libs.contains(StdLib::FFI) {
+			requiref(state, ffi::LUA_FFILIBNAME, ffi::luaopen_ffi, 1)?;
+			ffi::lua_pop(state, 1);
+		}
+	}
 
-    Ok(())
+	Ok(())
 }
 
 unsafe fn ref_stack_pop(extra: &mut ExtraData) -> c_int {
-    if let Some(free) = extra.ref_free.pop() {
-        ffi::lua_replace(extra.ref_thread, free);
-        return free;
-    }
+	if let Some(free) = extra.ref_free.pop() {
+		ffi::lua_replace(extra.ref_thread, free);
+		return free;
+	}
 
-    // Try to grow max stack size
-    if extra.ref_stack_top >= extra.ref_stack_size {
-        let mut inc = extra.ref_stack_size; // Try to double stack size
-        while inc > 0 && ffi::lua_checkstack(extra.ref_thread, inc) == 0 {
-            inc /= 2;
-        }
-        if inc == 0 {
-            // Pop item on top of the stack to avoid stack leaking and successfully run destructors
-            // during unwinding.
-            ffi::lua_pop(extra.ref_thread, 1);
-            let top = extra.ref_stack_top;
-            // It is a user error to create enough references to exhaust the Lua max stack size for
-            // the ref thread.
-            panic!(
-                "cannot create a Lua reference, out of auxiliary stack space (used {} slots)",
-                top
-            );
-        }
-        extra.ref_stack_size += inc;
-    }
-    extra.ref_stack_top += 1;
-    extra.ref_stack_top
+	// Try to grow max stack size
+	if extra.ref_stack_top >= extra.ref_stack_size {
+		let mut inc = extra.ref_stack_size; // Try to double stack size
+		while inc > 0 && ffi::lua_checkstack(extra.ref_thread, inc) == 0 {
+			inc /= 2;
+		}
+		if inc == 0 {
+			// Pop item on top of the stack to avoid stack leaking and successfully run destructors
+			// during unwinding.
+			ffi::lua_pop(extra.ref_thread, 1);
+			let top = extra.ref_stack_top;
+			// It is a user error to create enough references to exhaust the Lua max stack size for
+			// the ref thread.
+			panic!(
+				"cannot create a Lua reference, out of auxiliary stack space (used {} slots)",
+				top
+			);
+		}
+		extra.ref_stack_size += inc;
+	}
+	extra.ref_stack_top += 1;
+	extra.ref_stack_top
 }

--- a/src/multi.rs
+++ b/src/multi.rs
@@ -10,8 +10,8 @@ use crate::value::{FromLua, FromLuaMulti, MultiValue, Nil, ToLua, ToLuaMulti};
 
 /// Result is convertible to `MultiValue` following the common Lua idiom of returning the result
 /// on success, or in the case of an error, returning `nil` and an error message.
-impl<'lua, T: ToLua<'lua>, E: ToLua<'lua>> ToLuaMulti<'lua> for StdResult<T, E> {
-    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
+impl<T: ToLua, E: ToLua> ToLuaMulti for StdResult<T, E> {
+    fn to_lua_multi(self, lua: &Lua) -> Result<MultiValue> {
         let mut result = MultiValue::new_or_cached(lua);
         match self {
             Ok(v) => result.push_front(v.to_lua(lua)?),
@@ -24,30 +24,30 @@ impl<'lua, T: ToLua<'lua>, E: ToLua<'lua>> ToLuaMulti<'lua> for StdResult<T, E> 
     }
 }
 
-impl<'lua, T: ToLua<'lua>> ToLuaMulti<'lua> for T {
-    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
+impl<T: ToLua> ToLuaMulti for T {
+    fn to_lua_multi(self, lua: &Lua) -> Result<MultiValue> {
         let mut v = MultiValue::new_or_cached(lua);
         v.push_front(self.to_lua(lua)?);
         Ok(v)
     }
 }
 
-impl<'lua, T: FromLua<'lua>> FromLuaMulti<'lua> for T {
-    fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
+impl<T: FromLua> FromLuaMulti for T {
+    fn from_lua_multi(mut values: MultiValue, lua: &Lua) -> Result<Self> {
         let res = T::from_lua(values.pop_front().unwrap_or(Nil), lua);
         lua.cache_multivalue(values);
         res
     }
 }
 
-impl<'lua> ToLuaMulti<'lua> for MultiValue<'lua> {
-    fn to_lua_multi(self, _: &'lua Lua) -> Result<MultiValue<'lua>> {
+impl ToLuaMulti for MultiValue {
+    fn to_lua_multi(self, _: &Lua) -> Result<MultiValue> {
         Ok(self)
     }
 }
 
-impl<'lua> FromLuaMulti<'lua> for MultiValue<'lua> {
-    fn from_lua_multi(values: MultiValue<'lua>, _: &'lua Lua) -> Result<Self> {
+impl FromLuaMulti for MultiValue {
+    fn from_lua_multi(values: MultiValue, _: &Lua) -> Result<Self> {
         Ok(values)
     }
 }
@@ -123,16 +123,16 @@ impl<T> DerefMut for Variadic<T> {
     }
 }
 
-impl<'lua, T: ToLua<'lua>> ToLuaMulti<'lua> for Variadic<T> {
-    fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
+impl<T: ToLua> ToLuaMulti for Variadic<T> {
+    fn to_lua_multi(self, lua: &Lua) -> Result<MultiValue> {
         let mut values = MultiValue::new_or_cached(lua);
         values.refill(self.0.into_iter().map(|e| e.to_lua(lua)))?;
         Ok(values)
     }
 }
 
-impl<'lua, T: FromLua<'lua>> FromLuaMulti<'lua> for Variadic<T> {
-    fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
+impl<T: FromLua> FromLuaMulti for Variadic<T> {
+    fn from_lua_multi(mut values: MultiValue, lua: &Lua) -> Result<Self> {
         let res = values
             .drain_all()
             .map(|e| T::from_lua(e, lua))
@@ -145,14 +145,14 @@ impl<'lua, T: FromLua<'lua>> FromLuaMulti<'lua> for Variadic<T> {
 
 macro_rules! impl_tuple {
     () => (
-        impl<'lua> ToLuaMulti<'lua> for () {
-            fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
+        impl ToLuaMulti for () {
+            fn to_lua_multi(self, lua: &Lua) -> Result<MultiValue> {
                 Ok(MultiValue::new_or_cached(lua))
             }
         }
 
-        impl<'lua> FromLuaMulti<'lua> for () {
-            fn from_lua_multi(values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
+        impl FromLuaMulti for () {
+            fn from_lua_multi(values: MultiValue, lua: &Lua) -> Result<Self> {
                 lua.cache_multivalue(values);
                 Ok(())
             }
@@ -160,13 +160,13 @@ macro_rules! impl_tuple {
     );
 
     ($last:ident $($name:ident)*) => (
-        impl<'lua, $($name,)* $last> ToLuaMulti<'lua> for ($($name,)* $last,)
-            where $($name: ToLua<'lua>,)*
-                  $last: ToLuaMulti<'lua>
+        impl<$($name,)* $last> ToLuaMulti for ($($name,)* $last,)
+            where $($name: ToLua,)*
+                  $last: ToLuaMulti
         {
             #[allow(unused_mut)]
             #[allow(non_snake_case)]
-            fn to_lua_multi(self, lua: &'lua Lua) -> Result<MultiValue<'lua>> {
+            fn to_lua_multi(self, lua: &Lua) -> Result<MultiValue> {
                 let ($($name,)* $last,) = self;
 
                 let mut results = $last.to_lua_multi(lua)?;
@@ -175,13 +175,13 @@ macro_rules! impl_tuple {
             }
         }
 
-        impl<'lua, $($name,)* $last> FromLuaMulti<'lua> for ($($name,)* $last,)
-            where $($name: FromLua<'lua>,)*
-                  $last: FromLuaMulti<'lua>
+        impl<$($name,)* $last> FromLuaMulti for ($($name,)* $last,)
+            where $($name: FromLua,)*
+                  $last: FromLuaMulti
         {
             #[allow(unused_mut)]
             #[allow(non_snake_case)]
-            fn from_lua_multi(mut values: MultiValue<'lua>, lua: &'lua Lua) -> Result<Self> {
+            fn from_lua_multi(mut values: MultiValue, lua: &Lua) -> Result<Self> {
                 $(let $name = values.pop_front().unwrap_or(Nil);)*
                 let $last = FromLuaMulti::from_lua_multi(values, lua)?;
                 Ok(($(FromLua::from_lua($name, lua)?,)* $last,))

--- a/src/scope.rs
+++ b/src/scope.rs
@@ -11,14 +11,14 @@ use serde::Serialize;
 use crate::error::{Error, Result};
 use crate::ffi;
 use crate::function::Function;
-use crate::lua::Lua;
+use crate::lua::{Lua, LuaWeakRef};
 use crate::types::{Callback, CallbackUpvalue, LuaRef, MaybeSend};
 use crate::userdata::{
-    AnyUserData, MetaMethod, UserData, UserDataCell, UserDataFields, UserDataMethods,
+	AnyUserData, MetaMethod, UserData, UserDataCell, UserDataFields, UserDataMethods,
 };
 use crate::util::{
-    assert_stack, check_stack, get_userdata, init_userdata_metatable, push_table, rawset_field,
-    take_userdata, StackGuard,
+	assert_stack, check_stack, get_userdata, init_userdata_metatable, push_table, rawset_field,
+	take_userdata, StackGuard,
 };
 use crate::value::{FromLua, FromLuaMulti, MultiValue, ToLua, ToLuaMulti, Value};
 
@@ -27,9 +27,9 @@ use crate::userdata::USER_VALUE_MAXSLOT;
 
 #[cfg(feature = "async")]
 use {
-    crate::types::{AsyncCallback, AsyncCallbackUpvalue, AsyncPollUpvalue},
-    futures_core::future::Future,
-    futures_util::future::{self, TryFutureExt},
+	crate::types::{AsyncCallback, AsyncCallbackUpvalue, AsyncPollUpvalue},
+	futures_core::future::Future,
+	futures_util::future::{self, TryFutureExt},
 };
 
 /// Constructed by the [`Lua::scope`] method, allows temporarily creating Lua userdata and
@@ -38,22 +38,22 @@ use {
 /// See [`Lua::scope`] for more details.
 ///
 /// [`Lua::scope`]: crate::Lua.html::scope
-pub struct Scope<'lua, 'scope> {
-    lua: &'lua Lua,
-    destructors: RefCell<Vec<(LuaRef<'lua>, DestructorCallback<'lua>)>>,
-    _scope_invariant: PhantomData<Cell<&'scope ()>>,
+pub struct Scope<'scope> {
+	lua: LuaWeakRef,
+	destructors: RefCell<Vec<(LuaRef, DestructorCallback)>>,
+	_scope_invariant: PhantomData<Cell<&'scope ()>>,
 }
 
-type DestructorCallback<'lua> = Box<dyn Fn(LuaRef<'lua>) -> Vec<Box<dyn Any>> + 'lua>;
+type DestructorCallback = Box<dyn Fn(LuaRef) -> Vec<Box<dyn Any>>>;
 
-impl<'lua, 'scope> Scope<'lua, 'scope> {
-    pub(crate) fn new(lua: &'lua Lua) -> Scope<'lua, 'scope> {
-        Scope {
-            lua,
-            destructors: RefCell::new(Vec::new()),
-            _scope_invariant: PhantomData,
-        }
-    }
+impl<'scope> Scope<'scope> {
+	pub(crate) fn new(lua: &Lua) -> Scope<'scope> {
+		Scope {
+			lua: LuaWeakRef::new(lua),
+			destructors: RefCell::new(Vec::new()),
+			_scope_invariant: PhantomData,
+		}
+	}
 
     /// Wraps a Rust function or closure, creating a callable Lua function handle to it.
     ///
@@ -62,11 +62,11 @@ impl<'lua, 'scope> Scope<'lua, 'scope> {
     ///
     /// [`Lua::create_function`]: crate::Lua::create_function
     /// [`Lua::scope`]: crate::Lua::scope
-    pub fn create_function<'callback, A, R, F>(&'callback self, func: F) -> Result<Function<'lua>>
+    pub fn create_function<A, R, F>(&self, func: F) -> Result<Function>
     where
-        A: FromLuaMulti<'callback>,
-        R: ToLuaMulti<'callback>,
-        F: 'scope + Fn(&'callback Lua, A) -> Result<R>,
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        F: 'scope + Fn(&Lua, A) -> Result<R>,
     {
         // Safe, because 'scope must outlive 'callback (due to Self containing 'scope), however the
         // callback itself must be 'scope lifetime, so the function should not be able to capture
@@ -84,260 +84,262 @@ impl<'lua, 'scope> Scope<'lua, 'scope> {
         }
     }
 
-    /// Wraps a Rust mutable closure, creating a callable Lua function handle to it.
-    ///
-    /// This is a version of [`Lua::create_function_mut`] that creates a callback which expires
-    /// on scope drop. See [`Lua::scope`] and [`Scope::create_function`] for more details.
-    ///
-    /// [`Lua::create_function_mut`]: crate::Lua::create_function_mut
-    /// [`Lua::scope`]: crate::Lua::scope
-    /// [`Scope::create_function`]: #method.create_function
-    pub fn create_function_mut<'callback, A, R, F>(
-        &'callback self,
-        func: F,
-    ) -> Result<Function<'lua>>
-    where
-        A: FromLuaMulti<'callback>,
-        R: ToLuaMulti<'callback>,
-        F: 'scope + FnMut(&'callback Lua, A) -> Result<R>,
-    {
-        let func = RefCell::new(func);
-        self.create_function(move |lua, args| {
-            (*func
-                .try_borrow_mut()
-                .map_err(|_| Error::RecursiveMutCallback)?)(lua, args)
-        })
-    }
+	/// Wraps a Rust mutable closure, creating a callable Lua function handle to it.
+	///
+	/// This is a version of [`Lua::create_function_mut`] that creates a callback which expires
+	/// on scope drop. See [`Lua::scope`] and [`Scope::create_function`] for more details.
+	///
+	/// [`Lua::create_function_mut`]: crate::Lua::create_function_mut
+	/// [`Lua::scope`]: crate::Lua::scope
+	/// [`Scope::create_function`]: #method.create_function
+	pub fn create_function_mut<A, R, F>(
+		&self,
+		func: F,
+	) -> Result<Function>
+		where
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'scope + FnMut(&Lua, A) -> Result<R>,
+	{
+		let func = RefCell::new(func);
+		self.create_function(move |lua, args| {
+			(*func
+				.try_borrow_mut()
+				.map_err(|_| Error::RecursiveMutCallback)?)(lua, args)
+		})
+	}
 
-    /// Wraps a Rust async function or closure, creating a callable Lua function handle to it.
-    ///
-    /// This is a version of [`Lua::create_async_function`] that creates a callback which expires on
-    /// scope drop. See [`Lua::scope`] and [`Lua::async_scope`] for more details.
-    ///
-    /// Requires `feature = "async"`
-    ///
-    /// [`Lua::create_async_function`]: crate::Lua::create_async_function
-    /// [`Lua::scope`]: crate::Lua::scope
-    /// [`Lua::async_scope`]: crate::Lua::async_scope
-    #[cfg(feature = "async")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "async")))]
-    pub fn create_async_function<'callback, A, R, F, FR>(
-        &'callback self,
-        func: F,
-    ) -> Result<Function<'lua>>
-    where
-        A: FromLuaMulti<'callback>,
-        R: ToLuaMulti<'callback>,
-        F: 'scope + Fn(&'callback Lua, A) -> FR,
-        FR: 'callback + Future<Output = Result<R>>,
-    {
-        unsafe {
-            self.create_async_callback(Box::new(move |lua, args| {
-                let args = match A::from_lua_multi(args, lua) {
-                    Ok(args) => args,
-                    Err(e) => return Box::pin(future::err(e)),
-                };
-                Box::pin(func(lua, args).and_then(move |ret| future::ready(ret.to_lua_multi(lua))))
-            }))
-        }
-    }
+	/// Wraps a Rust async function or closure, creating a callable Lua function handle to it.
+	///
+	/// This is a version of [`Lua::create_async_function`] that creates a callback which expires on
+	/// scope drop. See [`Lua::scope`] and [`Lua::async_scope`] for more details.
+	///
+	/// Requires `feature = "async"`
+	///
+	/// [`Lua::create_async_function`]: crate::Lua::create_async_function
+	/// [`Lua::scope`]: crate::Lua::scope
+	/// [`Lua::async_scope`]: crate::Lua::async_scope
+	#[cfg(feature = "async")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "async")))]
+	pub fn create_async_function<'callback, A, R, F, FR>(
+		&'callback self,
+		func: F,
+	) -> Result<Function>
+		where
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'scope + Fn(&'callback Lua, A) -> FR,
+			FR: 'callback + Future<Output=Result<R>>,
+	{
+		unsafe {
+			self.create_async_callback(Box::new(move |lua, args| {
+				let args = match A::from_lua_multi(args, lua) {
+					Ok(args) => args,
+					Err(e) => return Box::pin(future::err(e)),
+				};
+				Box::pin(func(lua, args).and_then(move |ret| future::ready(ret.to_lua_multi(lua))))
+			}))
+		}
+	}
 
-    /// Create a Lua userdata object from a custom userdata type.
-    ///
-    /// This is a version of [`Lua::create_userdata`] that creates a userdata which expires on
-    /// scope drop, and does not require that the userdata type be Send (but still requires that the
-    /// UserData be 'static).
-    /// See [`Lua::scope`] for more details.
-    ///
-    /// [`Lua::create_userdata`]: crate::Lua::create_userdata
-    /// [`Lua::scope`]: crate::Lua::scope
-    pub fn create_userdata<T>(&self, data: T) -> Result<AnyUserData<'lua>>
-    where
-        T: 'static + UserData,
-    {
-        self.create_userdata_inner(UserDataCell::new(data))
-    }
+	/// Create a Lua userdata object from a custom userdata type.
+	///
+	/// This is a version of [`Lua::create_userdata`] that creates a userdata which expires on
+	/// scope drop, and does not require that the userdata type be Send (but still requires that the
+	/// UserData be 'static).
+	/// See [`Lua::scope`] for more details.
+	///
+	/// [`Lua::create_userdata`]: crate::Lua::create_userdata
+	/// [`Lua::scope`]: crate::Lua::scope
+	pub fn create_userdata<T>(&self, data: T) -> Result<AnyUserData>
+		where
+			T: 'static + UserData,
+	{
+		self.create_userdata_inner(UserDataCell::new(data))
+	}
 
-    /// Create a Lua userdata object from a custom serializable userdata type.
-    ///
-    /// This is a version of [`Lua::create_ser_userdata`] that creates a userdata which expires on
-    /// scope drop, and does not require that the userdata type be Send (but still requires that the
-    /// UserData be 'static).
-    /// See [`Lua::scope`] for more details.
-    ///
-    /// Requires `feature = "serialize"`
-    ///
-    /// [`Lua::create_ser_userdata`]: crate::Lua::create_ser_userdata
-    /// [`Lua::scope`]: crate::Lua::scope
-    #[cfg(feature = "serialize")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "serialize")))]
-    pub fn create_ser_userdata<T>(&self, data: T) -> Result<AnyUserData<'lua>>
-    where
-        T: 'static + UserData + Serialize,
-    {
-        self.create_userdata_inner(UserDataCell::new_ser(data))
-    }
+	/// Create a Lua userdata object from a custom serializable userdata type.
+	///
+	/// This is a version of [`Lua::create_ser_userdata`] that creates a userdata which expires on
+	/// scope drop, and does not require that the userdata type be Send (but still requires that the
+	/// UserData be 'static).
+	/// See [`Lua::scope`] for more details.
+	///
+	/// Requires `feature = "serialize"`
+	///
+	/// [`Lua::create_ser_userdata`]: crate::Lua::create_ser_userdata
+	/// [`Lua::scope`]: crate::Lua::scope
+	#[cfg(feature = "serialize")]
+	#[cfg_attr(docsrs, doc(cfg(feature = "serialize")))]
+	pub fn create_ser_userdata<T>(&self, data: T) -> Result<AnyUserData>
+		where
+			T: 'static + UserData + Serialize,
+	{
+		self.create_userdata_inner(UserDataCell::new_ser(data))
+	}
 
-    fn create_userdata_inner<T>(&self, data: UserDataCell<T>) -> Result<AnyUserData<'lua>>
-    where
-        T: 'static + UserData,
-    {
-        // Safe even though T may not be Send, because the parent Lua cannot be sent to another
-        // thread while the Scope is alive (or the returned AnyUserData handle even).
-        unsafe {
-            let ud = self.lua.make_userdata(data)?;
+	fn create_userdata_inner<T>(&self, data: UserDataCell<T>) -> Result<AnyUserData>
+		where
+			T: 'static + UserData,
+	{
+		// Safe even though T may not be Send, because the parent Lua cannot be sent to another
+		// thread while the Scope is alive (or the returned AnyUserData handle even).
+		unsafe {
+			let lua = self.lua.optional()?;
+			let ud = lua.make_userdata(data)?;
 
-            #[cfg(any(feature = "lua51", feature = "luajit"))]
-            let newtable = self.lua.create_table()?;
-            let destructor: DestructorCallback = Box::new(move |ud| {
-                let state = ud.lua.state;
-                let _sg = StackGuard::new(state);
-                assert_stack(state, 2);
+			#[cfg(any(feature = "lua51", feature = "luajit"))]
+				let newtable = lua.create_table()?;
+			let destructor: DestructorCallback = Box::new(move |ud| {
+				let lua = &ud.lua.required();
+				let state = lua.state;
+				let _sg = StackGuard::new(state);
+				assert_stack(state, 2);
 
-                // Check that userdata is not destructed (via `take()` call)
-                if ud.lua.push_userdata_ref(&ud).is_err() {
-                    return vec![];
-                }
+				// Check that userdata is not destructed (via `take()` call)
+				if lua.push_userdata_ref(&ud).is_err() {
+					return vec![];
+				}
 
-                // Clear associated user values
-                #[cfg(feature = "lua54")]
-                for i in 1..=USER_VALUE_MAXSLOT {
-                    ffi::lua_pushnil(state);
-                    ffi::lua_setiuservalue(state, -2, i as c_int);
-                }
-                #[cfg(any(feature = "lua53", feature = "lua52", feature = "luau"))]
-                {
-                    ffi::lua_pushnil(state);
-                    ffi::lua_setuservalue(state, -2);
-                }
-                #[cfg(any(feature = "lua51", feature = "luajit"))]
-                {
-                    ud.lua.push_ref(&newtable.0);
-                    ffi::lua_setuservalue(state, -2);
-                }
+				// Clear associated user values
+				#[cfg(feature = "lua54")]
+				for i in 1..=USER_VALUE_MAXSLOT {
+					ffi::lua_pushnil(state);
+					ffi::lua_setiuservalue(state, -2, i as c_int);
+				}
+				#[cfg(any(feature = "lua53", feature = "lua52", feature = "luau"))]
+				{
+					ffi::lua_pushnil(state);
+					ffi::lua_setuservalue(state, -2);
+				}
+				#[cfg(any(feature = "lua51", feature = "luajit"))]
+				{
+					lua.push_ref(&newtable.0);
+					ffi::lua_setuservalue(state, -2);
+				}
 
-                vec![Box::new(take_userdata::<UserDataCell<T>>(state))]
-            });
-            self.destructors
-                .borrow_mut()
-                .push((ud.0.clone(), destructor));
+				vec![Box::new(take_userdata::<UserDataCell<T>>(state))]
+			});
+			self.destructors
+				.borrow_mut()
+				.push((ud.0.clone(), destructor));
 
-            Ok(ud)
-        }
-    }
+			Ok(ud)
+		}
+	}
 
-    /// Create a Lua userdata object from a custom userdata type.
-    ///
-    /// This is a version of [`Lua::create_userdata`] that creates a userdata which expires on
-    /// scope drop, and does not require that the userdata type be Send or 'static. See
-    /// [`Lua::scope`] for more details.
-    ///
-    /// Lifting the requirement that the UserData type be 'static comes with some important
-    /// limitations, so if you only need to eliminate the Send requirement, it is probably better to
-    /// use [`Scope::create_userdata`] instead.
-    ///
-    /// The main limitation that comes from using non-'static userdata is that the produced userdata
-    /// will no longer have a `TypeId` associated with it, because `TypeId` can only work for
-    /// 'static types. This means that it is impossible, once the userdata is created, to get a
-    /// reference to it back *out* of an `AnyUserData` handle. This also implies that the
-    /// "function" type methods that can be added via [`UserDataMethods`] (the ones that accept
-    /// `AnyUserData` as a first parameter) are vastly less useful. Also, there is no way to re-use
-    /// a single metatable for multiple non-'static types, so there is a higher cost associated with
-    /// creating the userdata metatable each time a new userdata is created.
-    ///
-    /// [`Scope::create_userdata`]: #method.create_userdata
-    /// [`Lua::create_userdata`]: crate::Lua::create_userdata
-    /// [`Lua::scope`]:crate::Lua::scope
-    /// [`UserDataMethods`]: crate::UserDataMethods
-    pub fn create_nonstatic_userdata<T>(&self, data: T) -> Result<AnyUserData<'lua>>
-    where
-        T: 'scope + UserData,
-    {
-        let data = Rc::new(RefCell::new(data));
+	/// Create a Lua userdata object from a custom userdata type.
+	///
+	/// This is a version of [`Lua::create_userdata`] that creates a userdata which expires on
+	/// scope drop, and does not require that the userdata type be Send or 'static. See
+	/// [`Lua::scope`] for more details.
+	///
+	/// Lifting the requirement that the UserData type be 'static comes with some important
+	/// limitations, so if you only need to eliminate the Send requirement, it is probably better to
+	/// use [`Scope::create_userdata`] instead.
+	///
+	/// The main limitation that comes from using non-'static userdata is that the produced userdata
+	/// will no longer have a `TypeId` associated with it, because `TypeId` can only work for
+	/// 'static types. This means that it is impossible, once the userdata is created, to get a
+	/// reference to it back *out* of an `AnyUserData` handle. This also implies that the
+	/// "function" type methods that can be added via [`UserDataMethods`] (the ones that accept
+	/// `AnyUserData` as a first parameter) are vastly less useful. Also, there is no way to re-use
+	/// a single metatable for multiple non-'static types, so there is a higher cost associated with
+	/// creating the userdata metatable each time a new userdata is created.
+	///
+	/// [`Scope::create_userdata`]: #method.create_userdata
+	/// [`Lua::create_userdata`]: crate::Lua::create_userdata
+	/// [`Lua::scope`]:crate::Lua::scope
+	/// [`UserDataMethods`]: crate::UserDataMethods
+	pub fn create_nonstatic_userdata<T>(&self, data: T) -> Result<AnyUserData>
+		where
+			T: 'scope + UserData,
+	{
+		let data = Rc::new(RefCell::new(data));
 
-        // 'callback outliving 'scope is a lie to make the types work out, required due to the
-        // inability to work with the more correct callback type that is universally quantified over
-        // 'lua. This is safe though, because `UserData::add_methods` does not get to pick the 'lua
-        // lifetime, so none of the static methods UserData types can add can possibly capture
-        // parameters.
-        fn wrap_method<'scope, 'lua, 'callback: 'scope, T: 'scope>(
-            scope: &Scope<'lua, 'scope>,
-            data: Rc<RefCell<T>>,
-            ud_ptr: *const c_void,
-            method: NonStaticMethod<'callback, T>,
-        ) -> Result<Function<'lua>> {
-            // On methods that actually receive the userdata, we fake a type check on the passed in
-            // userdata, where we pretend there is a unique type per call to
-            // `Scope::create_nonstatic_userdata`. You can grab a method from a userdata and call
-            // it on a mismatched userdata type, which when using normal 'static userdata will fail
-            // with a type mismatch, but here without this check would proceed as though you had
-            // called the method on the original value (since we otherwise completely ignore the
-            // first argument).
-            let check_ud_type = move |lua: &'callback Lua, value| {
-                if let Some(Value::UserData(ud)) = value {
-                    unsafe {
-                        let _sg = StackGuard::new(lua.state);
-                        check_stack(lua.state, 2)?;
-                        lua.push_userdata_ref(&ud.0)?;
-                        if get_userdata(lua.state, -1) as *const _ == ud_ptr {
-                            return Ok(());
-                        }
-                    }
-                };
-                Err(Error::UserDataTypeMismatch)
-            };
+		// 'callback outliving 'scope is a lie to make the types work out, required due to the
+		// inability to work with the more correct callback type that is universally quantified over
+		// 'lua. This is safe though, because `UserData::add_methods` does not get to pick the 'lua
+		// lifetime, so none of the static methods UserData types can add can possibly capture
+		// parameters.
+		fn wrap_method<'scope, T: 'scope>(
+			scope: &Scope<'scope>,
+			data: Rc<RefCell<T>>,
+			ud_ptr: *const c_void,
+			method: NonStaticMethod<T>,
+		) -> Result<Function> {
+			// On methods that actually receive the userdata, we fake a type check on the passed in
+			// userdata, where we pretend there is a unique type per call to
+			// `Scope::create_nonstatic_userdata`. You can grab a method from a userdata and call
+			// it on a mismatched userdata type, which when using normal 'static userdata will fail
+			// with a type mismatch, but here without this check would proceed as though you had
+			// called the method on the original value (since we otherwise completely ignore the
+			// first argument).
+			let check_ud_type = move |lua: &Lua, value| {
+				if let Some(Value::UserData(ud)) = value {
+					unsafe {
+						let _sg = StackGuard::new(lua.state);
+						check_stack(lua.state, 2)?;
+						lua.push_userdata_ref(&ud.0)?;
+						if get_userdata(lua.state, -1) as *const _ == ud_ptr {
+							return Ok(());
+						}
+					}
+				};
+				Err(Error::UserDataTypeMismatch)
+			};
 
-            match method {
-                NonStaticMethod::Method(method) => {
-                    let f = Box::new(move |lua, mut args: MultiValue<'callback>| {
-                        check_ud_type(lua, args.pop_front())?;
-                        let data = data.try_borrow().map_err(|_| Error::UserDataBorrowError)?;
-                        method(lua, &*data, args)
-                    });
-                    unsafe { scope.create_callback(f) }
-                }
-                NonStaticMethod::MethodMut(method) => {
-                    let method = RefCell::new(method);
-                    let f = Box::new(move |lua, mut args: MultiValue<'callback>| {
-                        check_ud_type(lua, args.pop_front())?;
-                        let mut method = method
-                            .try_borrow_mut()
-                            .map_err(|_| Error::RecursiveMutCallback)?;
-                        let mut data = data
-                            .try_borrow_mut()
-                            .map_err(|_| Error::UserDataBorrowMutError)?;
-                        (*method)(lua, &mut *data, args)
-                    });
-                    unsafe { scope.create_callback(f) }
-                }
-                NonStaticMethod::Function(function) => unsafe { scope.create_callback(function) },
-                NonStaticMethod::FunctionMut(function) => {
-                    let function = RefCell::new(function);
-                    let f = Box::new(move |lua, args| {
-                        (*function
-                            .try_borrow_mut()
-                            .map_err(|_| Error::RecursiveMutCallback)?)(
-                            lua, args
-                        )
-                    });
-                    unsafe { scope.create_callback(f) }
-                }
-            }
-        }
+			match method {
+				NonStaticMethod::Method(method) => {
+					let f = Box::new(move |lua, mut args: MultiValue| {
+						check_ud_type(lua, args.pop_front())?;
+						let data = data.try_borrow().map_err(|_| Error::UserDataBorrowError)?;
+						method(lua, &*data, args)
+					});
+					unsafe { scope.create_callback(f) }
+				}
+				NonStaticMethod::MethodMut(method) => {
+					let method = RefCell::new(method);
+					let f = Box::new(move |lua, mut args: MultiValue| {
+						check_ud_type(lua, args.pop_front())?;
+						let mut method = method
+							.try_borrow_mut()
+							.map_err(|_| Error::RecursiveMutCallback)?;
+						let mut data = data
+							.try_borrow_mut()
+							.map_err(|_| Error::UserDataBorrowMutError)?;
+						(*method)(lua, &mut *data, args)
+					});
+					unsafe { scope.create_callback(f) }
+				}
+				NonStaticMethod::Function(function) => unsafe { scope.create_callback(function) },
+				NonStaticMethod::FunctionMut(function) => {
+					let function = RefCell::new(function);
+					let f = Box::new(move |lua, args| {
+						(*function
+							.try_borrow_mut()
+							.map_err(|_| Error::RecursiveMutCallback)?)(
+							lua, args,
+						)
+					});
+					unsafe { scope.create_callback(f) }
+				}
+			}
+		}
 
-        let mut ud_fields = NonStaticUserDataFields::default();
-        let mut ud_methods = NonStaticUserDataMethods::default();
-        T::add_fields(&mut ud_fields);
-        T::add_methods(&mut ud_methods);
+		let mut ud_fields = NonStaticUserDataFields::default();
+		let mut ud_methods = NonStaticUserDataMethods::default();
+		T::add_fields(&mut ud_fields);
+		T::add_methods(&mut ud_methods);
 
-        unsafe {
-            let lua = self.lua;
-            let _sg = StackGuard::new(lua.state);
-            check_stack(lua.state, 13)?;
+		unsafe {
+			let lua = &self.lua.optional()?;
+			let _sg = StackGuard::new(lua.state);
+			check_stack(lua.state, 13)?;
 
-            #[cfg(not(feature = "luau"))]
-            #[allow(clippy::let_and_return)]
-            let ud_ptr = protect_lua!(lua.state, 0, 1, |state| {
+			#[cfg(not(feature = "luau"))]
+				#[allow(clippy::let_and_return)]
+				let ud_ptr = protect_lua!(lua.state, 0, 1, |state| {
                 let ud =
                     ffi::lua_newuserdata(state, mem::size_of::<UserDataCell<Rc<RefCell<T>>>>());
 
@@ -350,553 +352,556 @@ impl<'lua, 'scope> Scope<'lua, 'scope> {
 
                 ud
             })?;
-            #[cfg(feature = "luau")]
-            let ud_ptr = {
-                crate::util::push_userdata::<UserDataCell<Rc<RefCell<T>>>>(
-                    lua.state,
-                    UserDataCell::new(data.clone()),
-                )?;
-                ffi::lua_touserdata(lua.state, -1)
-            };
+			#[cfg(feature = "luau")]
+				let ud_ptr = {
+				crate::util::push_userdata::<UserDataCell<Rc<RefCell<T>>>>(
+					lua.state,
+					UserDataCell::new(data.clone()),
+				)?;
+				ffi::lua_touserdata(lua.state, -1)
+			};
 
-            // Prepare metatable, add meta methods first and then meta fields
-            let meta_methods_nrec = ud_methods.meta_methods.len() + ud_fields.meta_fields.len() + 1;
-            push_table(lua.state, 0, meta_methods_nrec as c_int)?;
+			// Prepare metatable, add meta methods first and then meta fields
+			let meta_methods_nrec = ud_methods.meta_methods.len() + ud_fields.meta_fields.len() + 1;
+			push_table(lua.state, 0, meta_methods_nrec as c_int)?;
 
-            for (k, m) in ud_methods.meta_methods {
-                let data = data.clone();
-                lua.push_value(Value::Function(wrap_method(self, data, ud_ptr, m)?))?;
-                rawset_field(lua.state, -2, k.validate()?.name())?;
-            }
-            for (k, f) in ud_fields.meta_fields {
-                lua.push_value(f(mem::transmute(lua))?)?;
-                rawset_field(lua.state, -2, k.validate()?.name())?;
-            }
-            let metatable_index = ffi::lua_absindex(lua.state, -1);
+			for (k, m) in ud_methods.meta_methods {
+				let data = data.clone();
+				lua.push_value(Value::Function(wrap_method(self, data, ud_ptr, m)?))?;
+				rawset_field(lua.state, -2, k.validate()?.name())?;
+			}
+			for (k, f) in ud_fields.meta_fields {
+				lua.push_value(f(mem::transmute(lua))?)?;
+				rawset_field(lua.state, -2, k.validate()?.name())?;
+			}
+			let metatable_index = ffi::lua_absindex(lua.state, -1);
 
-            let mut field_getters_index = None;
-            let field_getters_nrec = ud_fields.field_getters.len();
-            if field_getters_nrec > 0 {
-                push_table(lua.state, 0, field_getters_nrec as c_int)?;
-                for (k, m) in ud_fields.field_getters {
-                    let data = data.clone();
-                    lua.push_value(Value::Function(wrap_method(self, data, ud_ptr, m)?))?;
-                    rawset_field(lua.state, -2, &k)?;
-                }
-                field_getters_index = Some(ffi::lua_absindex(lua.state, -1));
-            }
+			let mut field_getters_index = None;
+			let field_getters_nrec = ud_fields.field_getters.len();
+			if field_getters_nrec > 0 {
+				push_table(lua.state, 0, field_getters_nrec as c_int)?;
+				for (k, m) in ud_fields.field_getters {
+					let data = data.clone();
+					lua.push_value(Value::Function(wrap_method(self, data, ud_ptr, m)?))?;
+					rawset_field(lua.state, -2, &k)?;
+				}
+				field_getters_index = Some(ffi::lua_absindex(lua.state, -1));
+			}
 
-            let mut field_setters_index = None;
-            let field_setters_nrec = ud_fields.field_setters.len();
-            if field_setters_nrec > 0 {
-                push_table(lua.state, 0, field_setters_nrec as c_int)?;
-                for (k, m) in ud_fields.field_setters {
-                    let data = data.clone();
-                    lua.push_value(Value::Function(wrap_method(self, data, ud_ptr, m)?))?;
-                    rawset_field(lua.state, -2, &k)?;
-                }
-                field_setters_index = Some(ffi::lua_absindex(lua.state, -1));
-            }
+			let mut field_setters_index = None;
+			let field_setters_nrec = ud_fields.field_setters.len();
+			if field_setters_nrec > 0 {
+				push_table(lua.state, 0, field_setters_nrec as c_int)?;
+				for (k, m) in ud_fields.field_setters {
+					let data = data.clone();
+					lua.push_value(Value::Function(wrap_method(self, data, ud_ptr, m)?))?;
+					rawset_field(lua.state, -2, &k)?;
+				}
+				field_setters_index = Some(ffi::lua_absindex(lua.state, -1));
+			}
 
-            let mut methods_index = None;
-            let methods_nrec = ud_methods.methods.len();
-            if methods_nrec > 0 {
-                // Create table used for methods lookup
-                push_table(lua.state, 0, methods_nrec as c_int)?;
-                for (k, m) in ud_methods.methods {
-                    let data = data.clone();
-                    lua.push_value(Value::Function(wrap_method(self, data, ud_ptr, m)?))?;
-                    rawset_field(lua.state, -2, &k)?;
-                }
-                methods_index = Some(ffi::lua_absindex(lua.state, -1));
-            }
+			let mut methods_index = None;
+			let methods_nrec = ud_methods.methods.len();
+			if methods_nrec > 0 {
+				// Create table used for methods lookup
+				push_table(lua.state, 0, methods_nrec as c_int)?;
+				for (k, m) in ud_methods.methods {
+					let data = data.clone();
+					lua.push_value(Value::Function(wrap_method(self, data, ud_ptr, m)?))?;
+					rawset_field(lua.state, -2, &k)?;
+				}
+				methods_index = Some(ffi::lua_absindex(lua.state, -1));
+			}
 
-            init_userdata_metatable::<UserDataCell<Rc<RefCell<T>>>>(
-                lua.state,
-                metatable_index,
-                field_getters_index,
-                field_setters_index,
-                methods_index,
-            )?;
+			init_userdata_metatable::<UserDataCell<Rc<RefCell<T>>>>(
+				lua.state,
+				metatable_index,
+				field_getters_index,
+				field_setters_index,
+				methods_index,
+			)?;
 
-            let count = field_getters_index.map(|_| 1).unwrap_or(0)
-                + field_setters_index.map(|_| 1).unwrap_or(0)
-                + methods_index.map(|_| 1).unwrap_or(0);
-            ffi::lua_pop(lua.state, count);
+			let count = field_getters_index.map(|_| 1).unwrap_or(0)
+				+ field_setters_index.map(|_| 1).unwrap_or(0)
+				+ methods_index.map(|_| 1).unwrap_or(0);
+			ffi::lua_pop(lua.state, count);
 
-            let mt_ptr = ffi::lua_topointer(lua.state, -1);
-            // Write userdata just before attaching metatable with `__gc` metamethod
-            #[cfg(not(feature = "luau"))]
-            std::ptr::write(ud_ptr as _, UserDataCell::new(data));
-            ffi::lua_setmetatable(lua.state, -2);
-            let ud = AnyUserData(lua.pop_ref());
-            lua.register_userdata_metatable(mt_ptr, None);
+			let mt_ptr = ffi::lua_topointer(lua.state, -1);
+			// Write userdata just before attaching metatable with `__gc` metamethod
+			#[cfg(not(feature = "luau"))]
+			std::ptr::write(ud_ptr as _, UserDataCell::new(data));
+			ffi::lua_setmetatable(lua.state, -2);
+			let ud = AnyUserData(lua.pop_ref());
+			lua.register_userdata_metatable(mt_ptr, None);
 
-            #[cfg(any(feature = "lua51", feature = "luajit"))]
-            let newtable = lua.create_table()?;
-            let destructor: DestructorCallback = Box::new(move |ud| {
-                let state = ud.lua.state;
-                let _sg = StackGuard::new(state);
-                assert_stack(state, 2);
+			#[cfg(any(feature = "lua51", feature = "luajit"))]
+				let newtable = lua.create_table()?;
+			let destructor: DestructorCallback = Box::new(move |ud| {
+				let lua = &ud.lua.required();
+				let state = lua.state;
+				let _sg = StackGuard::new(state);
+				assert_stack(state, 2);
 
-                // Check that userdata is valid (very likely)
-                if ud.lua.push_userdata_ref(&ud).is_err() {
-                    return vec![];
-                }
+				// Check that userdata is valid (very likely)
+				if lua.push_userdata_ref(&ud).is_err() {
+					return vec![];
+				}
 
-                // Deregister metatable
-                ffi::lua_getmetatable(state, -1);
-                let mt_ptr = ffi::lua_topointer(state, -1);
-                ffi::lua_pop(state, 1);
-                ud.lua.deregister_userdata_metatable(mt_ptr);
+				// Deregister metatable
+				ffi::lua_getmetatable(state, -1);
+				let mt_ptr = ffi::lua_topointer(state, -1);
+				ffi::lua_pop(state, 1);
+				lua.deregister_userdata_metatable(mt_ptr);
 
-                // Clear associated user values
-                #[cfg(feature = "lua54")]
-                for i in 1..=USER_VALUE_MAXSLOT {
-                    ffi::lua_pushnil(state);
-                    ffi::lua_setiuservalue(state, -2, i as c_int);
-                }
-                #[cfg(any(feature = "lua53", feature = "lua52", feature = "luau"))]
-                {
-                    ffi::lua_pushnil(state);
-                    ffi::lua_setuservalue(state, -2);
-                }
-                #[cfg(any(feature = "lua51", feature = "luajit"))]
-                {
-                    ud.lua.push_ref(&newtable.0);
-                    ffi::lua_setuservalue(state, -2);
-                }
+				// Clear associated user values
+				#[cfg(feature = "lua54")]
+				for i in 1..=USER_VALUE_MAXSLOT {
+					ffi::lua_pushnil(state);
+					ffi::lua_setiuservalue(state, -2, i as c_int);
+				}
+				#[cfg(any(feature = "lua53", feature = "lua52", feature = "luau"))]
+				{
+					ffi::lua_pushnil(state);
+					ffi::lua_setuservalue(state, -2);
+				}
+				#[cfg(any(feature = "lua51", feature = "luajit"))]
+				{
+					lua.push_ref(&newtable.0);
+					ffi::lua_setuservalue(state, -2);
+				}
 
-                // A hack to drop non-static `T`
-                unsafe fn seal<T>(t: T) -> Box<dyn FnOnce() + 'static> {
-                    let f: Box<dyn FnOnce()> = Box::new(move || drop(t));
-                    mem::transmute(f)
-                }
+				// A hack to drop non-static `T`
+				unsafe fn seal<T>(t: T) -> Box<dyn FnOnce() + 'static> {
+					let f: Box<dyn FnOnce()> = Box::new(move || drop(t));
+					mem::transmute(f)
+				}
 
-                let ud = Box::new(seal(take_userdata::<UserDataCell<Rc<RefCell<T>>>>(state)));
-                vec![ud]
-            });
-            self.destructors
-                .borrow_mut()
-                .push((ud.0.clone(), destructor));
+				let ud = Box::new(seal(take_userdata::<UserDataCell<Rc<RefCell<T>>>>(state)));
+				vec![ud]
+			});
+			self.destructors
+				.borrow_mut()
+				.push((ud.0.clone(), destructor));
 
-            Ok(ud)
-        }
-    }
+			Ok(ud)
+		}
+	}
 
-    // Unsafe, because the callback can improperly capture any value with 'callback scope, such as
-    // improperly capturing an argument. Since the 'callback lifetime is chosen by the user and the
-    // lifetime of the callback itself is 'scope (non-'static), the borrow checker will happily pick
-    // a 'callback that outlives 'scope to allow this. In order for this to be safe, the callback
-    // must NOT capture any parameters.
-    unsafe fn create_callback<'callback>(
-        &self,
-        f: Callback<'callback, 'scope>,
-    ) -> Result<Function<'lua>> {
-        let f = mem::transmute::<Callback<'callback, 'scope>, Callback<'lua, 'static>>(f);
-        let f = self.lua.create_callback(f)?;
+	// Unsafe, because the callback can improperly capture any value with 'callback scope, such as
+	// improperly capturing an argument. Since the 'callback lifetime is chosen by the user and the
+	// lifetime of the callback itself is 'scope (non-'static), the borrow checker will happily pick
+	// a 'callback that outlives 'scope to allow this. In order for this to be safe, the callback
+	// must NOT capture any parameters.
+	unsafe fn create_callback(
+		&self,
+		f: Callback<'scope>,
+	) -> Result<Function> {
+		let f = mem::transmute::<Callback<'scope>, Callback<'static>>(f);
+		let lua = self.lua.optional()?;
+		let f = lua.create_callback(f)?;
 
-        let destructor: DestructorCallback = Box::new(|f| {
-            let state = f.lua.state;
-            let _sg = StackGuard::new(state);
-            assert_stack(state, 3);
+		let destructor: DestructorCallback = Box::new(move |f| {
+			let lua = lua.clone();
+			let state = lua.state;
+			let _sg = StackGuard::new(state);
+			assert_stack(state, 3);
 
-            f.lua.push_ref(&f);
+			lua.push_ref(&f);
 
-            // We know the destructor has not run yet because we hold a reference to the callback.
+			// We know the destructor has not run yet because we hold a reference to the callback.
 
-            ffi::lua_getupvalue(state, -1, 1);
-            let ud = take_userdata::<CallbackUpvalue>(state);
-            ffi::lua_pushnil(state);
-            ffi::lua_setupvalue(state, -2, 1);
+			ffi::lua_getupvalue(state, -1, 1);
+			let ud = take_userdata::<CallbackUpvalue>(state);
+			ffi::lua_pushnil(state);
+			ffi::lua_setupvalue(state, -2, 1);
 
-            vec![Box::new(ud)]
-        });
-        self.destructors
-            .borrow_mut()
-            .push((f.0.clone(), destructor));
+			vec![Box::new(ud)]
+		});
+		self.destructors
+			.borrow_mut()
+			.push((f.0.clone(), destructor));
 
-        Ok(f)
-    }
+		Ok(f)
+	}
 
-    #[cfg(feature = "async")]
-    unsafe fn create_async_callback<'callback>(
-        &self,
-        f: AsyncCallback<'callback, 'scope>,
-    ) -> Result<Function<'lua>> {
-        let f = mem::transmute::<AsyncCallback<'callback, 'scope>, AsyncCallback<'lua, 'static>>(f);
-        let f = self.lua.create_async_callback(f)?;
+	#[cfg(feature = "async")]
+	unsafe fn create_async_callback(
+		&self,
+		f: AsyncCallback<'scope>,
+	) -> Result<Function> {
+		let f = mem::transmute::<AsyncCallback<'scope>, AsyncCallback>(f);
+		let f = self.lua.create_async_callback(f)?;
 
-        // We need to pre-allocate strings to avoid failures in destructor.
-        let get_poll_str = self.lua.create_string("get_poll")?;
-        let poll_str = self.lua.create_string("poll")?;
-        let destructor: DestructorCallback = Box::new(move |f| {
-            let state = f.lua.state;
-            let _sg = StackGuard::new(state);
-            assert_stack(state, 5);
+		// We need to pre-allocate strings to avoid failures in destructor.
+		let get_poll_str = self.lua.create_string("get_poll")?;
+		let poll_str = self.lua.create_string("poll")?;
+		let destructor: DestructorCallback = Box::new(move |f| {
+			let state = f.lua.state;
+			let _sg = StackGuard::new(state);
+			assert_stack(state, 5);
 
-            f.lua.push_ref(&f);
+			f.lua.push_ref(&f);
 
-            // We know the destructor has not run yet because we hold a reference to the callback.
+			// We know the destructor has not run yet because we hold a reference to the callback.
 
-            // First, get the environment table
-            #[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
-            ffi::lua_getupvalue(state, -1, 1);
-            #[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
-            ffi::lua_getfenv(state, -1);
+			// First, get the environment table
+			#[cfg(any(feature = "lua54", feature = "lua53", feature = "lua52"))]
+			ffi::lua_getupvalue(state, -1, 1);
+			#[cfg(any(feature = "lua51", feature = "luajit", feature = "luau"))]
+			ffi::lua_getfenv(state, -1);
 
-            // Second, get the `get_poll()` closure using the corresponding key
-            f.lua.push_ref(&get_poll_str.0);
-            ffi::lua_rawget(state, -2);
+			// Second, get the `get_poll()` closure using the corresponding key
+			f.lua.push_ref(&get_poll_str.0);
+			ffi::lua_rawget(state, -2);
 
-            // Destroy all upvalues
-            ffi::lua_getupvalue(state, -1, 1);
-            let upvalue1 = take_userdata::<AsyncCallbackUpvalue>(state);
-            ffi::lua_pushnil(state);
-            ffi::lua_setupvalue(state, -2, 1);
+			// Destroy all upvalues
+			ffi::lua_getupvalue(state, -1, 1);
+			let upvalue1 = take_userdata::<AsyncCallbackUpvalue>(state);
+			ffi::lua_pushnil(state);
+			ffi::lua_setupvalue(state, -2, 1);
 
-            ffi::lua_pop(state, 1);
-            let mut data: Vec<Box<dyn Any>> = vec![Box::new(upvalue1)];
+			ffi::lua_pop(state, 1);
+			let mut data: Vec<Box<dyn Any>> = vec![Box::new(upvalue1)];
 
-            // Finally, get polled future and destroy it
-            f.lua.push_ref(&poll_str.0);
-            if ffi::lua_rawget(state, -2) == ffi::LUA_TFUNCTION {
-                ffi::lua_getupvalue(state, -1, 1);
-                let upvalue2 = take_userdata::<AsyncPollUpvalue>(state);
-                ffi::lua_pushnil(state);
-                ffi::lua_setupvalue(state, -2, 1);
-                data.push(Box::new(upvalue2));
-            }
+			// Finally, get polled future and destroy it
+			f.lua.push_ref(&poll_str.0);
+			if ffi::lua_rawget(state, -2) == ffi::LUA_TFUNCTION {
+				ffi::lua_getupvalue(state, -1, 1);
+				let upvalue2 = take_userdata::<AsyncPollUpvalue>(state);
+				ffi::lua_pushnil(state);
+				ffi::lua_setupvalue(state, -2, 1);
+				data.push(Box::new(upvalue2));
+			}
 
-            data
-        });
-        self.destructors
-            .borrow_mut()
-            .push((f.0.clone(), destructor));
+			data
+		});
+		self.destructors
+			.borrow_mut()
+			.push((f.0.clone(), destructor));
 
-        Ok(f)
-    }
+		Ok(f)
+	}
 }
 
-impl<'lua, 'scope> Drop for Scope<'lua, 'scope> {
-    fn drop(&mut self) {
-        // We separate the action of invalidating the userdata in Lua and actually dropping the
-        // userdata type into two phases. This is so that, in the event a userdata drop panics, we
-        // can be sure that all of the userdata in Lua is actually invalidated.
+impl<'scope> Drop for Scope<'scope> {
+	fn drop(&mut self) {
+		// We separate the action of invalidating the userdata in Lua and actually dropping the
+		// userdata type into two phases. This is so that, in the event a userdata drop panics, we
+		// can be sure that all of the userdata in Lua is actually invalidated.
 
-        // All destructors are non-panicking, so this is fine
-        let to_drop = self
-            .destructors
-            .get_mut()
-            .drain(..)
-            .flat_map(|(r, dest)| dest(r))
-            .collect::<Vec<_>>();
+		// All destructors are non-panicking, so this is fine
+		let to_drop = self
+			.destructors
+			.get_mut()
+			.drain(..)
+			.flat_map(|(r, dest)| dest(r))
+			.collect::<Vec<_>>();
 
-        drop(to_drop);
-    }
+		drop(to_drop);
+	}
 }
 
-enum NonStaticMethod<'lua, T> {
-    Method(Box<dyn Fn(&'lua Lua, &T, MultiValue<'lua>) -> Result<MultiValue<'lua>>>),
-    MethodMut(Box<dyn FnMut(&'lua Lua, &mut T, MultiValue<'lua>) -> Result<MultiValue<'lua>>>),
-    Function(Box<dyn Fn(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>>),
-    FunctionMut(Box<dyn FnMut(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>>>),
+enum NonStaticMethod<T> {
+	Method(Box<dyn Fn(&Lua, &T, MultiValue) -> Result<MultiValue>>),
+	MethodMut(Box<dyn FnMut(&Lua, &mut T, MultiValue) -> Result<MultiValue>>),
+	Function(Box<dyn Fn(&Lua, MultiValue) -> Result<MultiValue>>),
+	FunctionMut(Box<dyn FnMut(&Lua, MultiValue) -> Result<MultiValue>>),
 }
 
-struct NonStaticUserDataMethods<'lua, T: UserData> {
-    methods: Vec<(Vec<u8>, NonStaticMethod<'lua, T>)>,
-    meta_methods: Vec<(MetaMethod, NonStaticMethod<'lua, T>)>,
+struct NonStaticUserDataMethods<T: UserData> {
+	methods: Vec<(Vec<u8>, NonStaticMethod<T>)>,
+	meta_methods: Vec<(MetaMethod, NonStaticMethod<T>)>,
 }
 
-impl<'lua, T: UserData> Default for NonStaticUserDataMethods<'lua, T> {
-    fn default() -> NonStaticUserDataMethods<'lua, T> {
-        NonStaticUserDataMethods {
-            methods: Vec::new(),
-            meta_methods: Vec::new(),
-        }
-    }
+impl<T: UserData> Default for NonStaticUserDataMethods<T> {
+	fn default() -> NonStaticUserDataMethods<T> {
+		NonStaticUserDataMethods {
+			methods: Vec::new(),
+			meta_methods: Vec::new(),
+		}
+	}
 }
 
-impl<'lua, T: UserData> UserDataMethods<'lua, T> for NonStaticUserDataMethods<'lua, T> {
-    fn add_method<S, A, R, M>(&mut self, name: &S, method: M)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, &T, A) -> Result<R>,
-    {
-        self.methods.push((
-            name.as_ref().to_vec(),
-            NonStaticMethod::Method(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+impl<T: UserData> UserDataMethods<T> for NonStaticUserDataMethods<T> {
+	fn add_method<S, A, R, M>(&mut self, name: &S, method: M)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			M: 'static + MaybeSend + Fn(&Lua, &T, A) -> Result<R>,
+	{
+		self.methods.push((
+			name.as_ref().to_vec(),
+			NonStaticMethod::Method(Box::new(move |lua, ud, args| {
+				method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    fn add_method_mut<S, A, R, M>(&mut self, name: &S, mut method: M)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + FnMut(&'lua Lua, &mut T, A) -> Result<R>,
-    {
-        self.methods.push((
-            name.as_ref().to_vec(),
-            NonStaticMethod::MethodMut(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_method_mut<S, A, R, M>(&mut self, name: &S, mut method: M)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			M: 'static + MaybeSend + FnMut(&Lua, &mut T, A) -> Result<R>,
+	{
+		self.methods.push((
+			name.as_ref().to_vec(),
+			NonStaticMethod::MethodMut(Box::new(move |lua, ud, args| {
+				method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    #[cfg(feature = "async")]
-    fn add_async_method<S, A, R, M, MR>(&mut self, _name: &S, _method: M)
-    where
-        T: Clone,
-        S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, T, A) -> MR,
-        MR: 'lua + Future<Output = Result<R>>,
-    {
-        // The panic should never happen as async non-static code wouldn't compile
-        // Non-static lifetime must be bounded to 'lua lifetime
-        mlua_panic!("asynchronous methods are not supported for non-static userdata")
-    }
+	#[cfg(feature = "async")]
+	fn add_async_method<S, A, R, M, MR>(&mut self, _name: &S, _method: M)
+		where
+			T: Clone,
+			S: AsRef<[u8]> + ?Sized,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			M: 'static + MaybeSend + Fn(&Lua, T, A) -> MR,
+			MR: Future<Output=Result<R>>,
+	{
+		// The panic should never happen as async non-static code wouldn't compile
+		// Non-static lifetime must be bounded to 'lua lifetime
+		mlua_panic!("asynchronous methods are not supported for non-static userdata")
+	}
 
-    fn add_function<S, A, R, F>(&mut self, name: &S, function: F)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> Result<R>,
-    {
-        self.methods.push((
-            name.as_ref().to_vec(),
-            NonStaticMethod::Function(Box::new(move |lua, args| {
-                function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_function<S, A, R, F>(&mut self, name: &S, function: F)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + Fn(&Lua, A) -> Result<R>,
+	{
+		self.methods.push((
+			name.as_ref().to_vec(),
+			NonStaticMethod::Function(Box::new(move |lua, args| {
+				function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    fn add_function_mut<S, A, R, F>(&mut self, name: &S, mut function: F)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + FnMut(&'lua Lua, A) -> Result<R>,
-    {
-        self.methods.push((
-            name.as_ref().to_vec(),
-            NonStaticMethod::FunctionMut(Box::new(move |lua, args| {
-                function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_function_mut<S, A, R, F>(&mut self, name: &S, mut function: F)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + FnMut(&Lua, A) -> Result<R>,
+	{
+		self.methods.push((
+			name.as_ref().to_vec(),
+			NonStaticMethod::FunctionMut(Box::new(move |lua, args| {
+				function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    #[cfg(feature = "async")]
-    fn add_async_function<S, A, R, F, FR>(&mut self, _name: &S, _function: F)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> FR,
-        FR: 'lua + Future<Output = Result<R>>,
-    {
-        // The panic should never happen as async non-static code wouldn't compile
-        // Non-static lifetime must be bounded to 'lua lifetime
-        mlua_panic!("asynchronous functions are not supported for non-static userdata")
-    }
+	#[cfg(feature = "async")]
+	fn add_async_function<S, A, R, F, FR>(&mut self, _name: &S, _function: F)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + Fn(&Lua, A) -> FR,
+			FR: Future<Output=Result<R>>,
+	{
+		// The panic should never happen as async non-static code wouldn't compile
+		// Non-static lifetime must be bounded to 'lua lifetime
+		mlua_panic!("asynchronous functions are not supported for non-static userdata")
+	}
 
-    fn add_meta_method<S, A, R, M>(&mut self, meta: S, method: M)
-    where
-        S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, &T, A) -> Result<R>,
-    {
-        self.meta_methods.push((
-            meta.into(),
-            NonStaticMethod::Method(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_meta_method<S, A, R, M>(&mut self, meta: S, method: M)
+		where
+			S: Into<MetaMethod>,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			M: 'static + MaybeSend + Fn(&Lua, &T, A) -> Result<R>,
+	{
+		self.meta_methods.push((
+			meta.into(),
+			NonStaticMethod::Method(Box::new(move |lua, ud, args| {
+				method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    fn add_meta_method_mut<S, A, R, M>(&mut self, meta: S, mut method: M)
-    where
-        S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + FnMut(&'lua Lua, &mut T, A) -> Result<R>,
-    {
-        self.meta_methods.push((
-            meta.into(),
-            NonStaticMethod::MethodMut(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_meta_method_mut<S, A, R, M>(&mut self, meta: S, mut method: M)
+		where
+			S: Into<MetaMethod>,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			M: 'static + MaybeSend + FnMut(&Lua, &mut T, A) -> Result<R>,
+	{
+		self.meta_methods.push((
+			meta.into(),
+			NonStaticMethod::MethodMut(Box::new(move |lua, ud, args| {
+				method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    #[cfg(all(feature = "async", not(any(feature = "lua51", feature = "luau"))))]
-    fn add_async_meta_method<S, A, R, M, MR>(&mut self, _meta: S, _method: M)
-    where
-        T: Clone,
-        S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, T, A) -> MR,
-        MR: 'lua + Future<Output = Result<R>>,
-    {
-        // The panic should never happen as async non-static code wouldn't compile
-        // Non-static lifetime must be bounded to 'lua lifetime
-        mlua_panic!("asynchronous meta methods are not supported for non-static userdata")
-    }
+	#[cfg(all(feature = "async", not(any(feature = "lua51", feature = "luau"))))]
+	fn add_async_meta_method<S, A, R, M, MR>(&mut self, _meta: S, _method: M)
+		where
+			T: Clone,
+			S: Into<MetaMethod>,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			M: 'static + MaybeSend + Fn(&Lua, T, A) -> MR,
+			MR: 'lua + Future<Output=Result<R>>,
+	{
+		// The panic should never happen as async non-static code wouldn't compile
+		// Non-static lifetime must be bounded to 'lua lifetime
+		mlua_panic!("asynchronous meta methods are not supported for non-static userdata")
+	}
 
-    fn add_meta_function<S, A, R, F>(&mut self, meta: S, function: F)
-    where
-        S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> Result<R>,
-    {
-        self.meta_methods.push((
-            meta.into(),
-            NonStaticMethod::Function(Box::new(move |lua, args| {
-                function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_meta_function<S, A, R, F>(&mut self, meta: S, function: F)
+		where
+			S: Into<MetaMethod>,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + Fn(&Lua, A) -> Result<R>,
+	{
+		self.meta_methods.push((
+			meta.into(),
+			NonStaticMethod::Function(Box::new(move |lua, args| {
+				function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    fn add_meta_function_mut<S, A, R, F>(&mut self, meta: S, mut function: F)
-    where
-        S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + FnMut(&'lua Lua, A) -> Result<R>,
-    {
-        self.meta_methods.push((
-            meta.into(),
-            NonStaticMethod::FunctionMut(Box::new(move |lua, args| {
-                function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_meta_function_mut<S, A, R, F>(&mut self, meta: S, mut function: F)
+		where
+			S: Into<MetaMethod>,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + FnMut(&Lua, A) -> Result<R>,
+	{
+		self.meta_methods.push((
+			meta.into(),
+			NonStaticMethod::FunctionMut(Box::new(move |lua, args| {
+				function(lua, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    #[cfg(all(feature = "async", not(any(feature = "lua51", feature = "luau"))))]
-    fn add_async_meta_function<S, A, R, F, FR>(&mut self, _meta: S, _function: F)
-    where
-        S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> FR,
-        FR: 'lua + Future<Output = Result<R>>,
-    {
-        // The panic should never happen as async non-static code wouldn't compile
-        // Non-static lifetime must be bounded to 'lua lifetime
-        mlua_panic!("asynchronous meta functions are not supported for non-static userdata")
-    }
+	#[cfg(all(feature = "async", not(any(feature = "lua51", feature = "luau"))))]
+	fn add_async_meta_function<S, A, R, F, FR>(&mut self, _meta: S, _function: F)
+		where
+			S: Into<MetaMethod>,
+			A: FromLuaMulti,
+			R: ToLuaMulti,
+			F: 'static + MaybeSend + Fn(&Lua, A) -> FR,
+			FR: 'lua + Future<Output=Result<R>>,
+	{
+		// The panic should never happen as async non-static code wouldn't compile
+		// Non-static lifetime must be bounded to 'lua lifetime
+		mlua_panic!("asynchronous meta functions are not supported for non-static userdata")
+	}
 }
 
-struct NonStaticUserDataFields<'lua, T: UserData> {
-    field_getters: Vec<(Vec<u8>, NonStaticMethod<'lua, T>)>,
-    field_setters: Vec<(Vec<u8>, NonStaticMethod<'lua, T>)>,
-    #[allow(clippy::type_complexity)]
-    meta_fields: Vec<(MetaMethod, Box<dyn Fn(&'lua Lua) -> Result<Value<'lua>>>)>,
+struct NonStaticUserDataFields<T: UserData> {
+	field_getters: Vec<(Vec<u8>, NonStaticMethod<T>)>,
+	field_setters: Vec<(Vec<u8>, NonStaticMethod<T>)>,
+	#[allow(clippy::type_complexity)]
+	meta_fields: Vec<(MetaMethod, Box<dyn Fn(&Lua) -> Result<Value>>)>,
 }
 
-impl<'lua, T: UserData> Default for NonStaticUserDataFields<'lua, T> {
-    fn default() -> NonStaticUserDataFields<'lua, T> {
-        NonStaticUserDataFields {
-            field_getters: Vec::new(),
-            field_setters: Vec::new(),
-            meta_fields: Vec::new(),
-        }
-    }
+impl<T: UserData> Default for NonStaticUserDataFields<T> {
+	fn default() -> NonStaticUserDataFields<T> {
+		NonStaticUserDataFields {
+			field_getters: Vec::new(),
+			field_setters: Vec::new(),
+			meta_fields: Vec::new(),
+		}
+	}
 }
 
-impl<'lua, T: UserData> UserDataFields<'lua, T> for NonStaticUserDataFields<'lua, T> {
-    fn add_field_method_get<S, R, M>(&mut self, name: &S, method: M)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        R: ToLua<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, &T) -> Result<R>,
-    {
-        self.field_getters.push((
-            name.as_ref().to_vec(),
-            NonStaticMethod::Method(Box::new(move |lua, ud, _| {
-                method(lua, ud)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+impl<T: UserData> UserDataFields<T> for NonStaticUserDataFields<T> {
+	fn add_field_method_get<S, R, M>(&mut self, name: &S, method: M)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			R: ToLua,
+			M: 'static + MaybeSend + Fn(&Lua, &T) -> Result<R>,
+	{
+		self.field_getters.push((
+			name.as_ref().to_vec(),
+			NonStaticMethod::Method(Box::new(move |lua, ud, _| {
+				method(lua, ud)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    fn add_field_method_set<S, A, M>(&mut self, name: &S, mut method: M)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        A: FromLua<'lua>,
-        M: 'static + MaybeSend + FnMut(&'lua Lua, &mut T, A) -> Result<()>,
-    {
-        self.field_setters.push((
-            name.as_ref().to_vec(),
-            NonStaticMethod::MethodMut(Box::new(move |lua, ud, args| {
-                method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_field_method_set<S, A, M>(&mut self, name: &S, mut method: M)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			A: FromLua,
+			M: 'static + MaybeSend + FnMut(&Lua, &mut T, A) -> Result<()>,
+	{
+		self.field_setters.push((
+			name.as_ref().to_vec(),
+			NonStaticMethod::MethodMut(Box::new(move |lua, ud, args| {
+				method(lua, ud, A::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    fn add_field_function_get<S, R, F>(&mut self, name: &S, function: F)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        R: ToLua<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, AnyUserData<'lua>) -> Result<R>,
-    {
-        self.field_getters.push((
-            name.as_ref().to_vec(),
-            NonStaticMethod::Function(Box::new(move |lua, args| {
-                function(lua, AnyUserData::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_field_function_get<S, R, F>(&mut self, name: &S, function: F)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			R: ToLua,
+			F: 'static + MaybeSend + Fn(&Lua, AnyUserData) -> Result<R>,
+	{
+		self.field_getters.push((
+			name.as_ref().to_vec(),
+			NonStaticMethod::Function(Box::new(move |lua, args| {
+				function(lua, AnyUserData::from_lua_multi(args, lua)?)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    fn add_field_function_set<S, A, F>(&mut self, name: &S, mut function: F)
-    where
-        S: AsRef<[u8]> + ?Sized,
-        A: FromLua<'lua>,
-        F: 'static + MaybeSend + FnMut(&'lua Lua, AnyUserData<'lua>, A) -> Result<()>,
-    {
-        self.field_setters.push((
-            name.as_ref().to_vec(),
-            NonStaticMethod::FunctionMut(Box::new(move |lua, args| {
-                let (ud, val) = <_>::from_lua_multi(args, lua)?;
-                function(lua, ud, val)?.to_lua_multi(lua)
-            })),
-        ));
-    }
+	fn add_field_function_set<S, A, F>(&mut self, name: &S, mut function: F)
+		where
+			S: AsRef<[u8]> + ?Sized,
+			A: FromLua,
+			F: 'static + MaybeSend + FnMut(&Lua, AnyUserData, A) -> Result<()>,
+	{
+		self.field_setters.push((
+			name.as_ref().to_vec(),
+			NonStaticMethod::FunctionMut(Box::new(move |lua, args| {
+				let (ud, val) = <_>::from_lua_multi(args, lua)?;
+				function(lua, ud, val)?.to_lua_multi(lua)
+			})),
+		));
+	}
 
-    fn add_meta_field_with<S, R, F>(&mut self, meta: S, f: F)
-    where
-        S: Into<MetaMethod>,
-        F: 'static + MaybeSend + Fn(&'lua Lua) -> Result<R>,
-        R: ToLua<'lua>,
-    {
-        let meta = meta.into();
-        self.meta_fields.push((
-            meta.clone(),
-            Box::new(move |lua| {
-                let value = f(lua)?.to_lua(lua)?;
-                if meta == MetaMethod::Index || meta == MetaMethod::NewIndex {
-                    match value {
-                        Value::Nil | Value::Table(_) | Value::Function(_) => {}
-                        _ => {
-                            return Err(Error::MetaMethodTypeError {
-                                method: meta.to_string(),
-                                type_name: value.type_name(),
-                                message: Some("expected nil, table or function".to_string()),
-                            })
-                        }
-                    }
-                }
-                Ok(value)
-            }),
-        ));
-    }
+	fn add_meta_field_with<S, R, F>(&mut self, meta: S, f: F)
+		where
+			S: Into<MetaMethod>,
+			F: 'static + MaybeSend + Fn(&Lua) -> Result<R>,
+			R: ToLua,
+	{
+		let meta = meta.into();
+		self.meta_fields.push((
+			meta.clone(),
+			Box::new(move |lua| {
+				let value = f(lua)?.to_lua(lua)?;
+				if meta == MetaMethod::Index || meta == MetaMethod::NewIndex {
+					match value {
+						Value::Nil | Value::Table(_) | Value::Function(_) => {}
+						_ => {
+							return Err(Error::MetaMethodTypeError {
+								method: meta.to_string(),
+								type_name: value.type_name(),
+								message: Some("expected nil, table or function".to_string()),
+							});
+						}
+					}
+				}
+				Ok(value)
+			}),
+		));
+	}
 }

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -328,7 +328,7 @@ impl<'lua, 'de> serde::Deserializer<'de> for Deserializer {
 }
 
 struct SeqDeserializer {
-    seq: TableSequence<'lua, Value>,
+    seq: TableSequence<Value>,
     options: Options,
     visited: Rc<RefCell<FxHashSet<*const c_void>>>,
 }
@@ -398,7 +398,7 @@ impl<'de> de::SeqAccess<'de> for VecDeserializer {
 }
 
 struct MapDeserializer {
-    pairs: TablePairs<'lua, Value, Value>,
+    pairs: TablePairs<Value, Value>,
     value: Option<Value>,
     options: Options,
     visited: Rc<RefCell<FxHashSet<*const c_void>>>,
@@ -556,7 +556,7 @@ impl RecursionGuard {
     #[inline]
     fn new(table: &Table, visited: &Rc<RefCell<FxHashSet<*const c_void>>>) -> Self {
         let visited = Rc::clone(visited);
-        let lua = table.0.lua;
+        let lua = &table.0.lua.optional()?;
         let ptr =
             unsafe { lua.ref_thread_exec(|refthr| ffi::lua_topointer(refthr, table.0.index)) };
         visited.borrow_mut().insert(ptr);
@@ -578,7 +578,7 @@ fn check_value_if_skip(
 ) -> Result<bool> {
     match value {
         Value::Table(table) => {
-            let lua = table.0.lua;
+            let lua = &table.0.lua.optional()?;
             let ptr =
                 unsafe { lua.ref_thread_exec(|refthr| ffi::lua_topointer(refthr, table.0.index)) };
             if visited.borrow().contains(&ptr) {

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -556,7 +556,7 @@ impl RecursionGuard {
     #[inline]
     fn new(table: &Table, visited: &Rc<RefCell<FxHashSet<*const c_void>>>) -> Self {
         let visited = Rc::clone(visited);
-        let lua = &table.0.lua.optional()?;
+        let lua = &table.0.lua.required();
         let ptr =
             unsafe { lua.ref_thread_exec(|refthr| ffi::lua_topointer(refthr, table.0.index)) };
         visited.borrow_mut().insert(ptr);

--- a/src/serde/de.rs
+++ b/src/serde/de.rs
@@ -14,8 +14,8 @@ use crate::value::Value;
 
 /// A struct for deserializing Lua values into Rust values.
 #[derive(Debug)]
-pub struct Deserializer<'lua> {
-    value: Value<'lua>,
+pub struct Deserializer {
+    value: Value,
     options: Options,
     visited: Rc<RefCell<FxHashSet<*const c_void>>>,
 }
@@ -78,14 +78,14 @@ impl Options {
     }
 }
 
-impl<'lua> Deserializer<'lua> {
+impl Deserializer {
     /// Creates a new Lua Deserializer for the `Value`.
-    pub fn new(value: Value<'lua>) -> Self {
+    pub fn new(value: Value) -> Self {
         Self::new_with_options(value, Options::default())
     }
 
     /// Creates a new Lua Deserializer for the `Value` with custom options.
-    pub fn new_with_options(value: Value<'lua>, options: Options) -> Self {
+    pub fn new_with_options(value: Value, options: Options) -> Self {
         Deserializer {
             value,
             options,
@@ -94,7 +94,7 @@ impl<'lua> Deserializer<'lua> {
     }
 
     fn from_parts(
-        value: Value<'lua>,
+        value: Value,
         options: Options,
         visited: Rc<RefCell<FxHashSet<*const c_void>>>,
     ) -> Self {
@@ -106,7 +106,7 @@ impl<'lua> Deserializer<'lua> {
     }
 }
 
-impl<'lua, 'de> serde::Deserializer<'de> for Deserializer<'lua> {
+impl<'lua, 'de> serde::Deserializer<'de> for Deserializer {
     type Error = Error;
 
     #[inline]
@@ -327,13 +327,13 @@ impl<'lua, 'de> serde::Deserializer<'de> for Deserializer<'lua> {
     }
 }
 
-struct SeqDeserializer<'lua> {
-    seq: TableSequence<'lua, Value<'lua>>,
+struct SeqDeserializer {
+    seq: TableSequence<'lua, Value>,
     options: Options,
     visited: Rc<RefCell<FxHashSet<*const c_void>>>,
 }
 
-impl<'lua, 'de> de::SeqAccess<'de> for SeqDeserializer<'lua> {
+impl<'lua, 'de> de::SeqAccess<'de> for SeqDeserializer {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
@@ -397,15 +397,15 @@ impl<'de> de::SeqAccess<'de> for VecDeserializer {
     }
 }
 
-struct MapDeserializer<'lua> {
-    pairs: TablePairs<'lua, Value<'lua>, Value<'lua>>,
-    value: Option<Value<'lua>>,
+struct MapDeserializer {
+    pairs: TablePairs<'lua, Value, Value>,
+    value: Option<Value>,
     options: Options,
     visited: Rc<RefCell<FxHashSet<*const c_void>>>,
     processed: usize,
 }
 
-impl<'lua, 'de> de::MapAccess<'de> for MapDeserializer<'lua> {
+impl<'lua, 'de> de::MapAccess<'de> for MapDeserializer {
     type Error = Error;
 
     fn next_key_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
@@ -453,16 +453,16 @@ impl<'lua, 'de> de::MapAccess<'de> for MapDeserializer<'lua> {
     }
 }
 
-struct EnumDeserializer<'lua> {
+struct EnumDeserializer {
     variant: StdString,
-    value: Option<Value<'lua>>,
+    value: Option<Value>,
     options: Options,
     visited: Rc<RefCell<FxHashSet<*const c_void>>>,
 }
 
-impl<'lua, 'de> de::EnumAccess<'de> for EnumDeserializer<'lua> {
+impl<'lua, 'de> de::EnumAccess<'de> for EnumDeserializer {
     type Error = Error;
-    type Variant = VariantDeserializer<'lua>;
+    type Variant = VariantDeserializer;
 
     fn variant_seed<T>(self, seed: T) -> Result<(T::Value, Self::Variant)>
     where
@@ -478,13 +478,13 @@ impl<'lua, 'de> de::EnumAccess<'de> for EnumDeserializer<'lua> {
     }
 }
 
-struct VariantDeserializer<'lua> {
-    value: Option<Value<'lua>>,
+struct VariantDeserializer {
+    value: Option<Value>,
     options: Options,
     visited: Rc<RefCell<FxHashSet<*const c_void>>>,
 }
 
-impl<'lua, 'de> de::VariantAccess<'de> for VariantDeserializer<'lua> {
+impl<'lua, 'de> de::VariantAccess<'de> for VariantDeserializer {
     type Error = Error;
 
     fn unit_variant(self) -> Result<()> {

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -159,7 +159,7 @@ pub trait LuaSerdeExt {
     /// }
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    fn from_value<T: Deserialize>(&self, value: Value) -> Result<T>;
+    fn from_value<'a, T: Deserialize<'a>>(&self, value: Value) -> Result<T>;
 
     /// Deserializes a [`Value`] into any serde deserializable object with options.
     ///
@@ -191,7 +191,7 @@ pub trait LuaSerdeExt {
     /// }
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    fn from_value_with<T: Deserialize>(
+    fn from_value_with<'a, T: Deserialize<'a>>(
         &self,
         value: Value,
         options: de::Options,
@@ -228,16 +228,16 @@ impl LuaSerdeExt for Lua {
         t.serialize(ser::Serializer::new_with_options(self, options))
     }
 
-    fn from_value<T>(&self, value: Value) -> Result<T>
+    fn from_value<'a, T>(&self, value: Value) -> Result<T>
     where
-        T: Deserialize,
+        T: Deserialize<'a>,
     {
         T::deserialize(de::Deserializer::new(value))
     }
 
-    fn from_value_with<T>(&self, value: Value, options: de::Options) -> Result<T>
+    fn from_value_with<'a, T>(&self, value: Value, options: de::Options) -> Result<T>
     where
-        T: Deserialize,
+        T: Deserialize<'a>,
     {
         T::deserialize(de::Deserializer::new_with_options(value, options))
     }

--- a/src/serde/mod.rs
+++ b/src/serde/mod.rs
@@ -37,7 +37,7 @@ pub trait LuaSerdeExt {
     ///     Ok(())
     /// }
     /// ```
-    fn null(&'lua self) -> Value;
+    fn null(&self) -> Value;
 
     /// A metatable attachable to a Lua table to systematically encode it as Array (instead of Map).
     /// As result, encoded Array will contain only sequence part of the table, with the same length
@@ -68,7 +68,7 @@ pub trait LuaSerdeExt {
     ///     Ok(())
     /// }
     /// ```
-    fn array_metatable(&'lua self) -> Table;
+    fn array_metatable(&self) -> Table;
 
     /// Converts `T` into a [`Value`] instance.
     ///
@@ -101,7 +101,7 @@ pub trait LuaSerdeExt {
     ///     "#).exec()
     /// }
     /// ```
-    fn to_value<T: Serialize + ?Sized>(&'lua self, t: &T) -> Result<Value>;
+    fn to_value<T: Serialize + ?Sized>(&self, t: &T) -> Result<Value>;
 
     /// Converts `T` into a [`Value`] instance with options.
     ///
@@ -126,7 +126,7 @@ pub trait LuaSerdeExt {
     ///     "#).exec()
     /// }
     /// ```
-    fn to_value_with<T>(&'lua self, t: &T, options: ser::Options) -> Result<Value>
+    fn to_value_with<T>(&self, t: &T, options: ser::Options) -> Result<Value>
     where
         T: Serialize + ?Sized;
 
@@ -159,7 +159,7 @@ pub trait LuaSerdeExt {
     /// }
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    fn from_value<T: Deserialize>(&'lua self, value: Value) -> Result<T>;
+    fn from_value<T: Deserialize>(&self, value: Value) -> Result<T>;
 
     /// Deserializes a [`Value`] into any serde deserializable object with options.
     ///
@@ -192,18 +192,18 @@ pub trait LuaSerdeExt {
     /// ```
     #[allow(clippy::wrong_self_convention)]
     fn from_value_with<T: Deserialize>(
-        &'lua self,
+        &self,
         value: Value,
         options: de::Options,
     ) -> Result<T>;
 }
 
 impl LuaSerdeExt for Lua {
-    fn null(&'lua self) -> Value {
+    fn null(&self) -> Value {
         Value::LightUserData(LightUserData(ptr::null_mut()))
     }
 
-    fn array_metatable(&'lua self) -> Table {
+    fn array_metatable(&self) -> Table {
         unsafe {
             let _sg = StackGuard::new(self.state);
             assert_stack(self.state, 1);
@@ -214,28 +214,28 @@ impl LuaSerdeExt for Lua {
         }
     }
 
-    fn to_value<T>(&'lua self, t: &T) -> Result<Value>
+    fn to_value<T>(&self, t: &T) -> Result<Value>
     where
         T: Serialize + ?Sized,
     {
         t.serialize(ser::Serializer::new(self))
     }
 
-    fn to_value_with<T>(&'lua self, t: &T, options: ser::Options) -> Result<Value>
+    fn to_value_with<T>(&self, t: &T, options: ser::Options) -> Result<Value>
     where
         T: Serialize + ?Sized,
     {
         t.serialize(ser::Serializer::new_with_options(self, options))
     }
 
-    fn from_value<T>(&'lua self, value: Value) -> Result<T>
+    fn from_value<T>(&self, value: Value) -> Result<T>
     where
         T: Deserialize,
     {
         T::deserialize(de::Deserializer::new(value))
     }
 
-    fn from_value_with<T>(&'lua self, value: Value, options: de::Options) -> Result<T>
+    fn from_value_with<T>(&self, value: Value, options: de::Options) -> Result<T>
     where
         T: Deserialize,
     {

--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -110,7 +110,7 @@ macro_rules! lua_serialize_number {
     ($name:ident, $t:ty) => {
         #[inline]
         fn $name(self, value: $t) -> Result<Value> {
-            value.to_lua(self.lua)
+            value.to_lua(&self.lua.optional()?)
         }
     };
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -18,9 +18,9 @@ use crate::util::{assert_stack, StackGuard};
 ///
 /// Unlike Rust strings, Lua strings may not be valid UTF-8.
 #[derive(Clone, Debug)]
-pub struct String<'lua>(pub(crate) LuaRef<'lua>);
+pub struct String(pub(crate) LuaRef);
 
-impl<'lua> String<'lua> {
+impl String {
     /// Get a `&str` slice if the Lua string is valid UTF-8.
     ///
     /// # Examples
@@ -93,7 +93,7 @@ impl<'lua> String<'lua> {
 
     /// Get the bytes that make up this string, including the trailing nul byte.
     pub fn as_bytes_with_nul(&self) -> &[u8] {
-        let lua = self.0.lua;
+        let lua = self.0.lua.required();
         unsafe {
             let _sg = StackGuard::new(lua.state);
             assert_stack(lua.state, 1);
@@ -114,13 +114,13 @@ impl<'lua> String<'lua> {
     }
 }
 
-impl<'lua> AsRef<[u8]> for String<'lua> {
+impl AsRef<[u8]> for String {
     fn as_ref(&self) -> &[u8] {
         self.as_bytes()
     }
 }
 
-impl<'lua> Borrow<[u8]> for String<'lua> {
+impl Borrow<[u8]> for String {
     fn borrow(&self) -> &[u8] {
         self.as_bytes()
     }
@@ -134,7 +134,7 @@ impl<'lua> Borrow<[u8]> for String<'lua> {
 // The only downside is that this disallows a comparison with `Cow<str>`, as that only implements
 // `AsRef<str>`, which collides with this impl. Requiring `AsRef<str>` would fix that, but limit us
 // in other ways.
-impl<'lua, T> PartialEq<T> for String<'lua>
+impl<T> PartialEq<T> for String
 where
     T: AsRef<[u8]>,
 {
@@ -143,16 +143,16 @@ where
     }
 }
 
-impl<'lua> Eq for String<'lua> {}
+impl Eq for String {}
 
-impl<'lua> Hash for String<'lua> {
+impl Hash for String {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.as_bytes().hash(state);
     }
 }
 
 #[cfg(feature = "serialize")]
-impl<'lua> Serialize for String<'lua> {
+impl Serialize for String {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/table.rs
+++ b/src/table.rs
@@ -500,7 +500,7 @@ impl Table {
 
     #[cfg(feature = "serialize")]
     pub(crate) fn is_array(&self) -> bool {
-        let lua = &self.0.lua.optional()?;
+        let lua = &self.0.lua.required();
         unsafe {
             let _sg = StackGuard::new(lua.state);
             assert_stack(lua.state, 3);
@@ -693,7 +693,7 @@ impl Serialize for Table {
             static VISITED: RefCell<FxHashSet<*const c_void>> = RefCell::new(FxHashSet::default());
         }
 
-        let lua = &self.0.lua.optional()?;
+        let lua = &self.0.lua.required();
         let ptr = unsafe { lua.ref_thread_exec(|refthr| ffi::lua_topointer(refthr, self.0.index)) };
         let res = VISITED.with(|visited| {
             {

--- a/src/types.rs
+++ b/src/types.rs
@@ -14,7 +14,7 @@ use crate::error::Result;
 use crate::ffi;
 #[cfg(not(feature = "luau"))]
 use crate::hook::Debug;
-use crate::lua::{ExtraData, Lua};
+use crate::lua::{ExtraData, Lua, LuaWeakRef};
 use crate::util::{assert_stack, StackGuard};
 use crate::value::MultiValue;
 
@@ -27,25 +27,25 @@ pub type Number = ffi::lua_Number;
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct LightUserData(pub *mut c_void);
 
-pub(crate) type Callback<'lua, 'a> =
-    Box<dyn Fn(&'lua Lua, MultiValue<'lua>) -> Result<MultiValue<'lua>> + 'a>;
+pub(crate) type Callback<'a> =
+    Box<dyn Fn(&'a Lua, MultiValue) -> Result<MultiValue> + 'a>;
 
 pub(crate) struct Upvalue<T> {
     pub(crate) data: T,
     pub(crate) extra: Arc<UnsafeCell<ExtraData>>,
 }
 
-pub(crate) type CallbackUpvalue = Upvalue<Callback<'static, 'static>>;
+pub(crate) type CallbackUpvalue = Upvalue<Callback<'static>>;
 
 #[cfg(feature = "async")]
-pub(crate) type AsyncCallback<'lua, 'a> =
-    Box<dyn Fn(&'lua Lua, MultiValue<'lua>) -> LocalBoxFuture<'lua, Result<MultiValue<'lua>>> + 'a>;
+pub(crate) type AsyncCallback<'a> =
+    Box<dyn Fn(&Lua, MultiValue) -> LocalBoxFuture<Result<MultiValue>> + 'a>;
 
 #[cfg(feature = "async")]
-pub(crate) type AsyncCallbackUpvalue = Upvalue<AsyncCallback<'static, 'static>>;
+pub(crate) type AsyncCallbackUpvalue = Upvalue<AsyncCallback<'static>>;
 
 #[cfg(feature = "async")]
-pub(crate) type AsyncPollUpvalue = Upvalue<LocalBoxFuture<'static, Result<MultiValue<'static>>>>;
+pub(crate) type AsyncPollUpvalue = Upvalue<LocalBoxFuture<'static, Result<MultiValue>>>;
 
 /// Type to set next Luau VM action after executing interrupt function.
 #[cfg(any(feature = "luau", doc))]
@@ -148,34 +148,36 @@ impl RegistryKey {
     }
 }
 
-pub(crate) struct LuaRef<'lua> {
-    pub(crate) lua: &'lua Lua,
+pub(crate) struct LuaRef {
+    pub(crate) lua: LuaWeakRef,
     pub(crate) index: c_int,
 }
 
-impl<'lua> fmt::Debug for LuaRef<'lua> {
+impl fmt::Debug for LuaRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Ref({})", self.index)
     }
 }
 
-impl<'lua> Clone for LuaRef<'lua> {
+impl Clone for LuaRef {
     fn clone(&self) -> Self {
-        self.lua.clone_ref(self)
+        self.lua.required().clone_ref(self)
     }
 }
 
-impl<'lua> Drop for LuaRef<'lua> {
+impl Drop for LuaRef {
     fn drop(&mut self) {
-        if self.index > 0 {
-            self.lua.drop_ref(self);
+        if let Ok(lua) = self.lua.optional() {
+            if self.index > 0 {
+                lua.drop_ref(self);
+            }
         }
     }
 }
 
-impl<'lua> PartialEq for LuaRef<'lua> {
+impl PartialEq for LuaRef {
     fn eq(&self, other: &Self) -> bool {
-        let lua = self.lua;
+        let lua = self.lua.required();
         unsafe {
             let _sg = StackGuard::new(lua.state);
             assert_stack(lua.state, 2);

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -288,7 +288,7 @@ impl From<&str> for MetaMethod {
 /// Method registry for [`UserData`] implementors.
 ///
 /// [`UserData`]: crate::UserData
-pub trait UserDataMethods<'lua, T: UserData> {
+pub trait UserDataMethods<T: UserData> {
     /// Add a regular method which accepts a `&T` as the first parameter.
     ///
     /// Regular methods are implemented by overriding the `__index` metamethod and returning the
@@ -299,9 +299,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_method<S, A, R, M>(&mut self, name: &S, method: M)
     where
         S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, &T, A) -> Result<R>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        M: 'static + MaybeSend + Fn(&Lua, &T, A) -> Result<R>;
 
     /// Add a regular method which accepts a `&mut T` as the first parameter.
     ///
@@ -311,9 +311,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_method_mut<S, A, R, M>(&mut self, name: &S, method: M)
     where
         S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + FnMut(&'lua Lua, &mut T, A) -> Result<R>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        M: 'static + MaybeSend + FnMut(&Lua, &mut T, A) -> Result<R>;
 
     /// Add an async method which accepts a `T` as the first parameter and returns Future.
     /// The passed `T` is cloned from the original value.
@@ -329,10 +329,10 @@ pub trait UserDataMethods<'lua, T: UserData> {
     where
         T: Clone,
         S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, T, A) -> MR,
-        MR: 'lua + Future<Output = Result<R>>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        M: 'static + MaybeSend + Fn(&Lua, T, A) -> MR,
+        MR: Future<Output = Result<R>>;
 
     /// Add a regular method as a function which accepts generic arguments, the first argument will
     /// be a [`AnyUserData`] of type `T` if the method is called with Lua method syntax:
@@ -347,9 +347,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_function<S, A, R, F>(&mut self, name: &S, function: F)
     where
         S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> Result<R>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        F: 'static + MaybeSend + Fn(&Lua, A) -> Result<R>;
 
     /// Add a regular method as a mutable function which accepts generic arguments.
     ///
@@ -359,9 +359,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_function_mut<S, A, R, F>(&mut self, name: &S, function: F)
     where
         S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + FnMut(&'lua Lua, A) -> Result<R>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        F: 'static + MaybeSend + FnMut(&Lua, A) -> Result<R>;
 
     /// Add a regular method as an async function which accepts generic arguments
     /// and returns Future.
@@ -376,10 +376,10 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_async_function<S, A, R, F, FR>(&mut self, name: &S, function: F)
     where
         S: AsRef<[u8]> + ?Sized,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> FR,
-        FR: 'lua + Future<Output = Result<R>>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        F: 'static + MaybeSend + Fn(&Lua, A) -> FR,
+        FR: Future<Output = Result<R>>;
 
     /// Add a metamethod which accepts a `&T` as the first parameter.
     ///
@@ -392,9 +392,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_meta_method<S, A, R, M>(&mut self, meta: S, method: M)
     where
         S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, &T, A) -> Result<R>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        M: 'static + MaybeSend + Fn(&Lua, &T, A) -> Result<R>;
 
     /// Add a metamethod as a function which accepts a `&mut T` as the first parameter.
     ///
@@ -407,9 +407,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_meta_method_mut<S, A, R, M>(&mut self, meta: S, method: M)
     where
         S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + FnMut(&'lua Lua, &mut T, A) -> Result<R>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        M: 'static + MaybeSend + FnMut(&Lua, &mut T, A) -> Result<R>;
 
     /// Add an async metamethod which accepts a `T` as the first parameter and returns Future.
     /// The passed `T` is cloned from the original value.
@@ -425,9 +425,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     where
         T: Clone,
         S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, T, A) -> MR,
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        M: 'static + MaybeSend + Fn(&Lua, T, A) -> MR,
         MR: 'lua + Future<Output = Result<R>>;
 
     /// Add a metamethod which accepts generic arguments.
@@ -438,9 +438,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_meta_function<S, A, R, F>(&mut self, meta: S, function: F)
     where
         S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> Result<R>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        F: 'static + MaybeSend + Fn(&Lua, A) -> Result<R>;
 
     /// Add a metamethod as a mutable function which accepts generic arguments.
     ///
@@ -450,9 +450,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_meta_function_mut<S, A, R, F>(&mut self, meta: S, function: F)
     where
         S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + FnMut(&'lua Lua, A) -> Result<R>;
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        F: 'static + MaybeSend + FnMut(&Lua, A) -> Result<R>;
 
     /// Add a metamethod which accepts generic arguments and returns Future.
     ///
@@ -466,9 +466,9 @@ pub trait UserDataMethods<'lua, T: UserData> {
     fn add_async_meta_function<S, A, R, F, FR>(&mut self, name: S, function: F)
     where
         S: Into<MetaMethod>,
-        A: FromLuaMulti<'lua>,
-        R: ToLuaMulti<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, A) -> FR,
+        A: FromLuaMulti,
+        R: ToLuaMulti,
+        F: 'static + MaybeSend + Fn(&Lua, A) -> FR,
         FR: 'lua + Future<Output = Result<R>>;
 
     //
@@ -476,21 +476,21 @@ pub trait UserDataMethods<'lua, T: UserData> {
     //
 
     #[doc(hidden)]
-    fn add_callback(&mut self, _name: Vec<u8>, _callback: Callback<'lua, 'static>) {}
+    fn add_callback(&mut self, _name: Vec<u8>, _callback: Callback<'static>) {}
 
     #[doc(hidden)]
     #[cfg(feature = "async")]
-    fn add_async_callback(&mut self, _name: Vec<u8>, _callback: AsyncCallback<'lua, 'static>) {}
+    fn add_async_callback(&mut self, _name: Vec<u8>, _callback: AsyncCallback<'static>) {}
 
     #[doc(hidden)]
-    fn add_meta_callback(&mut self, _meta: MetaMethod, _callback: Callback<'lua, 'static>) {}
+    fn add_meta_callback(&mut self, _meta: MetaMethod, _callback: Callback<'static>) {}
 
     #[doc(hidden)]
     #[cfg(feature = "async")]
     fn add_async_meta_callback(
         &mut self,
         _meta: MetaMethod,
-        _callback: AsyncCallback<'lua, 'static>,
+        _callback: AsyncCallback<'static>,
     ) {
     }
 }
@@ -498,7 +498,7 @@ pub trait UserDataMethods<'lua, T: UserData> {
 /// Field registry for [`UserData`] implementors.
 ///
 /// [`UserData`]: crate::UserData
-pub trait UserDataFields<'lua, T: UserData> {
+pub trait UserDataFields<T: UserData> {
     /// Add a regular field getter as a method which accepts a `&T` as the parameter.
     ///
     /// Regular field getters are implemented by overriding the `__index` metamethod and returning the
@@ -509,8 +509,8 @@ pub trait UserDataFields<'lua, T: UserData> {
     fn add_field_method_get<S, R, M>(&mut self, name: &S, method: M)
     where
         S: AsRef<[u8]> + ?Sized,
-        R: ToLua<'lua>,
-        M: 'static + MaybeSend + Fn(&'lua Lua, &T) -> Result<R>;
+        R: ToLua,
+        M: 'static + MaybeSend + Fn(&Lua, &T) -> Result<R>;
 
     /// Add a regular field setter as a method which accepts a `&mut T` as the first parameter.
     ///
@@ -522,8 +522,8 @@ pub trait UserDataFields<'lua, T: UserData> {
     fn add_field_method_set<S, A, M>(&mut self, name: &S, method: M)
     where
         S: AsRef<[u8]> + ?Sized,
-        A: FromLua<'lua>,
-        M: 'static + MaybeSend + FnMut(&'lua Lua, &mut T, A) -> Result<()>;
+        A: FromLua,
+        M: 'static + MaybeSend + FnMut(&Lua, &mut T, A) -> Result<()>;
 
     /// Add a regular field getter as a function which accepts a generic [`AnyUserData`] of type `T`
     /// argument.
@@ -535,8 +535,8 @@ pub trait UserDataFields<'lua, T: UserData> {
     fn add_field_function_get<S, R, F>(&mut self, name: &S, function: F)
     where
         S: AsRef<[u8]> + ?Sized,
-        R: ToLua<'lua>,
-        F: 'static + MaybeSend + Fn(&'lua Lua, AnyUserData<'lua>) -> Result<R>;
+        R: ToLua,
+        F: 'static + MaybeSend + Fn(&Lua, AnyUserData) -> Result<R>;
 
     /// Add a regular field setter as a function which accepts a generic [`AnyUserData`] of type `T`
     /// first argument.
@@ -548,8 +548,8 @@ pub trait UserDataFields<'lua, T: UserData> {
     fn add_field_function_set<S, A, F>(&mut self, name: &S, function: F)
     where
         S: AsRef<[u8]> + ?Sized,
-        A: FromLua<'lua>,
-        F: 'static + MaybeSend + FnMut(&'lua Lua, AnyUserData<'lua>, A) -> Result<()>;
+        A: FromLua,
+        F: 'static + MaybeSend + FnMut(&Lua, AnyUserData, A) -> Result<()>;
 
     /// Add a metamethod value computed from `f`.
     ///
@@ -562,18 +562,18 @@ pub trait UserDataFields<'lua, T: UserData> {
     fn add_meta_field_with<S, R, F>(&mut self, meta: S, f: F)
     where
         S: Into<MetaMethod>,
-        F: 'static + MaybeSend + Fn(&'lua Lua) -> Result<R>,
-        R: ToLua<'lua>;
+        F: 'static + MaybeSend + Fn(&Lua) -> Result<R>,
+        R: ToLua;
 
     //
     // Below are internal methods used in generated code
     //
 
     #[doc(hidden)]
-    fn add_field_getter(&mut self, _name: Vec<u8>, _callback: Callback<'lua, 'static>) {}
+    fn add_field_getter(&mut self, _name: Vec<u8>, _callback: Callback<'static>) {}
 
     #[doc(hidden)]
-    fn add_field_setter(&mut self, _name: Vec<u8>, _callback: Callback<'lua, 'static>) {}
+    fn add_field_setter(&mut self, _name: Vec<u8>, _callback: Callback<'static>) {}
 }
 
 /// Trait for custom userdata types.
@@ -611,11 +611,11 @@ pub trait UserDataFields<'lua, T: UserData> {
 /// struct MyUserData(i32);
 ///
 /// impl UserData for MyUserData {
-///     fn add_fields<'lua, F: UserDataFields<'lua, Self>>(fields: &mut F) {
+///     fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
 ///         fields.add_field_method_get("val", |_, this| Ok(this.0));
 ///     }
 ///
-///     fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+///     fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
 ///         methods.add_method_mut("add", |_, this, value: i32| {
 ///             this.0 += value;
 ///             Ok(())
@@ -645,10 +645,10 @@ pub trait UserDataFields<'lua, T: UserData> {
 /// [`UserDataMethods`]: crate::UserDataMethods
 pub trait UserData: Sized {
     /// Adds custom fields specific to this userdata.
-    fn add_fields<'lua, F: UserDataFields<'lua, Self>>(_fields: &mut F) {}
+    fn add_fields<F: UserDataFields<Self>>(_fields: &mut F) {}
 
     /// Adds custom methods and operators specific to this userdata.
-    fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(_methods: &mut M) {}
+    fn add_methods<M: UserDataMethods<Self>>(_methods: &mut M) {}
 }
 
 // Wraps UserData in a way to always implement `serde::Serialize` trait.
@@ -783,9 +783,9 @@ impl Serialize for UserDataSerializeError {
 /// [`is`]: crate::AnyUserData::is
 /// [`borrow`]: crate::AnyUserData::borrow
 #[derive(Clone, Debug)]
-pub struct AnyUserData<'lua>(pub(crate) LuaRef<'lua>);
+pub struct AnyUserData(pub(crate) LuaRef);
 
-impl<'lua> AnyUserData<'lua> {
+impl AnyUserData {
     /// Checks whether the type of this userdata is `T`.
     pub fn is<T: 'static + UserData>(&self) -> bool {
         match self.inspect(|_: &UserDataCell<T>| Ok(())) {
@@ -822,7 +822,7 @@ impl<'lua> AnyUserData<'lua> {
     ///
     /// All associated user values will be also cleared.
     pub fn take<T: 'static + UserData>(&self) -> Result<T> {
-        let lua = self.0.lua;
+        let lua = self.0.lua.optional()?;
         unsafe {
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 3)?;
@@ -866,7 +866,7 @@ impl<'lua> AnyUserData<'lua> {
     /// [`get_user_value`]: #method.get_user_value
     /// [`set_nth_user_value`]: #method.set_nth_user_value
     #[inline]
-    pub fn set_user_value<V: ToLua<'lua>>(&self, v: V) -> Result<()> {
+    pub fn set_user_value<V: ToLua>(&self, v: V) -> Result<()> {
         self.set_nth_user_value(1, v)
     }
 
@@ -877,7 +877,7 @@ impl<'lua> AnyUserData<'lua> {
     /// [`set_user_value`]: #method.set_user_value
     /// [`get_nth_user_value`]: #method.get_nth_user_value
     #[inline]
-    pub fn get_user_value<V: FromLua<'lua>>(&self) -> Result<V> {
+    pub fn get_user_value<V: FromLua>(&self) -> Result<V> {
         self.get_nth_user_value(1)
     }
 
@@ -891,14 +891,14 @@ impl<'lua> AnyUserData<'lua> {
     /// For other Lua versions this functionality is provided using a wrapping table.
     ///
     /// [`get_nth_user_value`]: #method.get_nth_user_value
-    pub fn set_nth_user_value<V: ToLua<'lua>>(&self, n: usize, v: V) -> Result<()> {
+    pub fn set_nth_user_value<V: ToLua>(&self, n: usize, v: V) -> Result<()> {
         if n < 1 || n > u16::MAX as usize {
             return Err(Error::RuntimeError(
                 "user value index out of bounds".to_string(),
             ));
         }
 
-        let lua = self.0.lua;
+        let lua = &self.0.lua.optional()?;
         unsafe {
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 5)?;
@@ -945,14 +945,14 @@ impl<'lua> AnyUserData<'lua> {
     /// For other Lua versions this functionality is provided using a wrapping table.
     ///
     /// [`set_nth_user_value`]: #method.set_nth_user_value
-    pub fn get_nth_user_value<V: FromLua<'lua>>(&self, n: usize) -> Result<V> {
+    pub fn get_nth_user_value<V: FromLua>(&self, n: usize) -> Result<V> {
         if n < 1 || n > u16::MAX as usize {
             return Err(Error::RuntimeError(
                 "user value index out of bounds".to_string(),
             ));
         }
 
-        let lua = self.0.lua;
+        let lua = &self.0.lua.optional()?;
         unsafe {
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 4)?;
@@ -989,9 +989,9 @@ impl<'lua> AnyUserData<'lua> {
     pub fn set_named_user_value<S, V>(&self, name: &S, v: V) -> Result<()>
     where
         S: AsRef<[u8]> + ?Sized,
-        V: ToLua<'lua>,
+        V: ToLua,
     {
-        let lua = self.0.lua;
+        let lua = &self.0.lua.optional()?;
         unsafe {
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 5)?;
@@ -1028,9 +1028,9 @@ impl<'lua> AnyUserData<'lua> {
     pub fn get_named_user_value<S, V>(&self, name: &S) -> Result<V>
     where
         S: AsRef<[u8]> + ?Sized,
-        V: FromLua<'lua>,
+        V: FromLua,
     {
-        let lua = self.0.lua;
+        let lua = &self.0.lua.optional()?;
         unsafe {
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 4)?;
@@ -1060,13 +1060,13 @@ impl<'lua> AnyUserData<'lua> {
     /// For `T: UserData + 'static` returned metatable is shared among all instances of type `T`.
     ///
     /// [`UserDataMetatable`]: crate::UserDataMetatable
-    pub fn get_metatable(&self) -> Result<UserDataMetatable<'lua>> {
+    pub fn get_metatable(&self) -> Result<UserDataMetatable> {
         self.get_raw_metatable().map(UserDataMetatable)
     }
 
-    fn get_raw_metatable(&self) -> Result<Table<'lua>> {
+    fn get_raw_metatable(&self) -> Result<Table> {
         unsafe {
-            let lua = self.0.lua;
+            let lua = &self.0.lua.optional()?;
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 3)?;
 
@@ -1102,7 +1102,7 @@ impl<'lua> AnyUserData<'lua> {
         T: 'static + UserData,
         F: FnOnce(&'a UserDataCell<T>) -> Result<R>,
     {
-        let lua = self.0.lua;
+        let lua = &self.0.lua.optional()?;
         unsafe {
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 2)?;
@@ -1118,13 +1118,13 @@ impl<'lua> AnyUserData<'lua> {
     }
 }
 
-impl<'lua> PartialEq for AnyUserData<'lua> {
+impl PartialEq for AnyUserData {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0
     }
 }
 
-impl<'lua> AsRef<AnyUserData<'lua>> for AnyUserData<'lua> {
+impl AsRef<AnyUserData> for AnyUserData {
     #[inline]
     fn as_ref(&self) -> &Self {
         self
@@ -1140,14 +1140,14 @@ unsafe fn getuservalue_table(state: *mut ffi::lua_State, idx: c_int) -> c_int {
 
 /// Handle to a `UserData` metatable.
 #[derive(Clone, Debug)]
-pub struct UserDataMetatable<'lua>(pub(crate) Table<'lua>);
+pub struct UserDataMetatable(pub(crate) Table);
 
-impl<'lua> UserDataMetatable<'lua> {
+impl UserDataMetatable {
     /// Gets the value associated to `key` from the metatable.
     ///
     /// If no value is associated to `key`, returns the `Nil` value.
     /// Access to restricted metamethods such as `__gc` or `__metatable` will cause an error.
-    pub fn get<K: Into<MetaMethod>, V: FromLua<'lua>>(&self, key: K) -> Result<V> {
+    pub fn get<K: Into<MetaMethod>, V: FromLua>(&self, key: K) -> Result<V> {
         self.0.raw_get(key.into().validate()?.name())
     }
 
@@ -1157,7 +1157,7 @@ impl<'lua> UserDataMetatable<'lua> {
     /// Access to restricted metamethods such as `__gc` or `__metatable` will cause an error.
     /// Setting `__index` or `__newindex` metamethods is also restricted because their values are cached
     /// for `mlua` internal usage.
-    pub fn set<K: Into<MetaMethod>, V: ToLua<'lua>>(&self, key: K, value: V) -> Result<()> {
+    pub fn set<K: Into<MetaMethod>, V: ToLua>(&self, key: K, value: V) -> Result<()> {
         let key = key.into().validate()?;
         // `__index` and `__newindex` cannot be changed in runtime, because values are cached
         if key == MetaMethod::Index || key == MetaMethod::NewIndex {
@@ -1176,7 +1176,7 @@ impl<'lua> UserDataMetatable<'lua> {
     /// The pairs are wrapped in a [`Result`], since they are lazily converted to `V` type.
     ///
     /// [`Result`]: crate::Result
-    pub fn pairs<V: FromLua<'lua>>(self) -> UserDataMetatablePairs<'lua, V> {
+    pub fn pairs<V: FromLua>(self) -> UserDataMetatablePairs<V> {
         UserDataMetatablePairs(self.0.pairs())
     }
 }
@@ -1189,11 +1189,11 @@ impl<'lua> UserDataMetatable<'lua> {
 ///
 /// [`UserData`]: crate::UserData
 /// [`UserDataMetatable::pairs`]: crate::UserDataMetatable::method.pairs
-pub struct UserDataMetatablePairs<'lua, V>(TablePairs<'lua, StdString, V>);
+pub struct UserDataMetatablePairs<V>(TablePairs<StdString, V>);
 
-impl<'lua, V> Iterator for UserDataMetatablePairs<'lua, V>
+impl<V> Iterator for UserDataMetatablePairs<V>
 where
-    V: FromLua<'lua>,
+    V: FromLua,
 {
     type Item = Result<(MetaMethod, V)>;
 
@@ -1213,12 +1213,12 @@ where
 }
 
 #[cfg(feature = "serialize")]
-impl<'lua> Serialize for AnyUserData<'lua> {
+impl Serialize for AnyUserData {
     fn serialize<S>(&self, serializer: S) -> StdResult<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let lua = self.0.lua;
+        let lua = &self.0.lua.optional()?;
         let data = unsafe {
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 3).map_err(ser::Error::custom)?;

--- a/src/userdata.rs
+++ b/src/userdata.rs
@@ -1218,7 +1218,7 @@ impl Serialize for AnyUserData {
     where
         S: Serializer,
     {
-        let lua = &self.0.lua.optional()?;
+        let lua = &self.0.lua.required();
         let data = unsafe {
             let _sg = StackGuard::new(lua.state);
             check_stack(lua.state, 3).map_err(ser::Error::custom)?;

--- a/tests/scope.rs
+++ b/tests/scope.rs
@@ -75,7 +75,7 @@ fn test_scope_userdata_fields() -> Result<()> {
     struct MyUserData<'a>(&'a Cell<i64>);
 
     impl<'a> UserData for MyUserData<'a> {
-        fn add_fields<'lua, F: UserDataFields<'lua, Self>>(fields: &mut F) {
+        fn add_fields< F: UserDataFields< Self>>(fields: &mut F) {
             fields.add_field_method_get("val", |_, data| Ok(data.0.get()));
             fields.add_field_method_set("val", |_, data, val| {
                 data.0.set(val);
@@ -110,7 +110,7 @@ fn test_scope_userdata_methods() -> Result<()> {
     struct MyUserData<'a>(&'a Cell<i64>);
 
     impl<'a> UserData for MyUserData<'a> {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods< M: UserDataMethods< Self>>(methods: &mut M) {
             methods.add_method("inc", |_, data, ()| {
                 data.0.set(data.0.get() + 1);
                 Ok(())
@@ -151,7 +151,7 @@ fn test_scope_userdata_functions() -> Result<()> {
     struct MyUserData<'a>(&'a i64);
 
     impl<'a> UserData for MyUserData<'a> {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods< M: UserDataMethods< Self>>(methods: &mut M) {
             methods.add_meta_function(MetaMethod::Add, |lua, ()| {
                 let globals = lua.globals();
                 globals.set("i", globals.get::<_, i64>("i")? + 1)?;
@@ -193,7 +193,7 @@ fn test_scope_userdata_mismatch() -> Result<()> {
     struct MyUserData<'a>(&'a Cell<i64>);
 
     impl<'a> UserData for MyUserData<'a> {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods< M: UserDataMethods< Self>>(methods: &mut M) {
             methods.add_method("inc", |_, data, ()| {
                 data.0.set(data.0.get() + 1);
                 Ok(())
@@ -247,7 +247,7 @@ fn test_scope_userdata_drop() -> Result<()> {
     struct MyUserData(Rc<()>);
 
     impl UserData for MyUserData {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods< M: UserDataMethods< Self>>(methods: &mut M) {
             methods.add_method("method", |_, _, ()| Ok(()));
         }
     }
@@ -305,7 +305,7 @@ fn test_scope_nonstatic_userdata_drop() -> Result<()> {
     struct MyUserData<'a>(&'a Cell<i64>, Arc<()>);
 
     impl<'a> UserData for MyUserData<'a> {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods< M: UserDataMethods< Self>>(methods: &mut M) {
             methods.add_method("inc", |_, data, ()| {
                 data.0.set(data.0.get() + 1);
                 Ok(())

--- a/tests/static.rs
+++ b/tests/static.rs
@@ -7,7 +7,7 @@ fn test_static_lua() -> Result<()> {
     let lua = Lua::new().into_static();
 
     thread_local! {
-        static TABLE: RefCell<Option<Table<'static>>> = RefCell::new(None);
+        static TABLE: RefCell<Option<Table>> = RefCell::new(None);
     }
 
     let f = lua.create_function(|_, table: Table| {
@@ -38,7 +38,7 @@ fn test_static_lua_coroutine() -> Result<()> {
     let lua = Lua::new().into_static();
 
     thread_local! {
-        static TABLE: RefCell<Option<Table<'static>>> = RefCell::new(None);
+        static TABLE: RefCell<Option<Table>> = RefCell::new(None);
     }
 
     let f = lua.create_function(|_, table: Table| {

--- a/tests/userdata.rs
+++ b/tests/userdata.rs
@@ -40,7 +40,7 @@ fn test_methods() -> Result<()> {
     struct MyUserData(i64);
 
     impl UserData for MyUserData {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
             methods.add_method("get_value", |_, data, ()| Ok(data.0));
             methods.add_method_mut("set_value", |_, data, args| {
                 data.0 = args;
@@ -91,7 +91,7 @@ fn test_metamethods() -> Result<()> {
     struct MyUserData(i64);
 
     impl UserData for MyUserData {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
             methods.add_method("get", |_, data, ()| Ok(data.0));
             methods.add_meta_function(
                 MetaMethod::Add,
@@ -197,7 +197,7 @@ fn test_metamethod_close() -> Result<()> {
     struct MyUserData(Arc<AtomicI64>);
 
     impl UserData for MyUserData {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
             methods.add_method("get", |_, data, ()| Ok(data.0.load(Ordering::Relaxed)));
             methods.add_meta_method(MetaMethod::Close, |_, data, _err: Value| {
                 data.0.store(0, Ordering::Relaxed);
@@ -243,7 +243,7 @@ fn test_gc_userdata() -> Result<()> {
     }
 
     impl UserData for MyUserdata {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
             methods.add_method("access", |_, this, ()| {
                 assert!(this.id == 123);
                 Ok(())
@@ -282,7 +282,7 @@ fn test_userdata_take() -> Result<()> {
     struct MyUserdata(Arc<i64>);
 
     impl UserData for MyUserdata {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
             methods.add_method("num", |_, this, ()| Ok(*this.0))
         }
     }
@@ -410,7 +410,7 @@ fn test_functions() -> Result<()> {
     struct MyUserData(i64);
 
     impl UserData for MyUserData {
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
             methods.add_function("get_value", |_, ud: AnyUserData| {
                 Ok(ud.borrow::<MyUserData>()?.0)
             });
@@ -461,7 +461,7 @@ fn test_fields() -> Result<()> {
     struct MyUserData(i64);
 
     impl UserData for MyUserData {
-        fn add_fields<'lua, F: UserDataFields<'lua, Self>>(fields: &mut F) {
+        fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
             fields.add_field_method_get("val", |_, data| Ok(data.0));
             fields.add_field_method_set("val", |_, data, val| {
                 data.0 = val;
@@ -517,11 +517,11 @@ fn test_metatable() -> Result<()> {
     struct MyUserData(i64);
 
     impl UserData for MyUserData {
-        fn add_fields<'lua, F: UserDataFields<'lua, Self>>(fields: &mut F) {
+        fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
             fields.add_meta_field_with("__type_name", |_| Ok("MyUserData"));
         }
 
-        fn add_methods<'lua, M: UserDataMethods<'lua, Self>>(methods: &mut M) {
+        fn add_methods<M: UserDataMethods<Self>>(methods: &mut M) {
             methods.add_function("my_type_name", |_, data: AnyUserData| {
                 let metatable = data.get_metatable()?;
                 metatable.get::<_, String>("__type_name")
@@ -566,7 +566,7 @@ fn test_metatable() -> Result<()> {
     struct MyUserData2(i64);
 
     impl UserData for MyUserData2 {
-        fn add_fields<'lua, F: UserDataFields<'lua, Self>>(fields: &mut F) {
+        fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
             fields.add_meta_field_with("__index", |_| Ok(1));
         }
     }
@@ -585,7 +585,7 @@ fn test_userdata_wrapped() -> Result<()> {
     struct MyUserData(i64);
 
     impl UserData for MyUserData {
-        fn add_fields<'lua, F: UserDataFields<'lua, Self>>(fields: &mut F) {
+        fn add_fields<F: UserDataFields<Self>>(fields: &mut F) {
             fields.add_field_method_get("data", |_, this| Ok(this.0));
             fields.add_field_method_set("data", |_, this, val| {
                 this.0 = val;


### PR DESCRIPTION
## The code is just a proof of concept, this really should not be merged because of panic! usage.
Hi there! This pull-request shows off how lifetimes might get removed from the api. In small use cases mlua is really useful but for games like `rustaria` which i am developing together with some other people, it makes this library unusable. 

Most of the lifetimes have been replaced by the `LuaWeakRef` struct which takes a Weak reference of the Lua internals. If the context gets dropped the object will either return `Err(Error::LuaUnavailable)` or panic (which is not ideal, many returns need to return result now). I would like to have your input on this, as I think this is a great start on making mlua integrable in huge systems.