### PR TITLE
SerializeToLua, DeserializeFromLua

### DIFF
--- a/src/serde/ser.rs
+++ b/src/serde/ser.rs
@@ -483,3 +483,21 @@ impl<'lua> ser::SerializeStructVariant for SerializeStructVariant<'lua> {
         Ok(Value::Table(table))
     }
 }
+
+pub struct SerializeToLua<T: Serialize>(T);
+impl<T: Serialize> SerializeToLua<T> {
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+impl<T: Serialize> From<T> for SerializeToLua<T> {
+    fn from(t: T) -> Self {
+        Self(t)
+    }
+}
+impl<'lua, T: Serialize> ToLua<'lua> for SerializeToLua<T> {
+    fn to_lua(self, lua: &'lua Lua) -> Result<Value<'lua>> {
+        let serializer = Serializer::new(lua);
+        self.0.serialize(serializer)
+    }
+}


### PR DESCRIPTION
#152 

But, I don't think `SerializeToLua` and `DeserializeFromLua` is a good idea.
I expect `fn add_one(_: &Lua, arg: Test) -> LuaResult<Test>` rather than `fn add_one(_: &Lua, arg: DeserializeFromLua<Test>) -> LuaResult<SerializeToLua<Test>>`.