### PR TITLE
Implement utilities for MultiValue

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -1,4 +1,5 @@
 use std::iter::{self, FromIterator};
+use std::ops::Index;
 use std::os::raw::c_void;
 use std::{ptr, slice, str, vec};
 
@@ -242,6 +243,15 @@ impl<'a, 'lua> IntoIterator for &'a MultiValue<'lua> {
     }
 }
 
+impl<'lua> Index<usize> for MultiValue<'lua> {
+    type Output = Value<'lua>;
+
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[self.0.len() - index - 1]
+    }
+}
+
 impl<'lua> MultiValue<'lua> {
     #[inline]
     pub fn from_vec(mut v: Vec<Value<'lua>>) -> MultiValue<'lua> {
@@ -262,13 +272,13 @@ impl<'lua> MultiValue<'lua> {
     }
 
     #[inline]
-    pub(crate) fn push_front(&mut self, value: Value<'lua>) {
-        self.0.push(value);
+    pub fn pop_front(&mut self) -> Option<Value<'lua>> {
+        self.0.pop()
     }
 
     #[inline]
-    pub(crate) fn pop_front(&mut self) -> Option<Value<'lua>> {
-        self.0.pop()
+    pub fn push_front(&mut self, value: Value<'lua>) {
+        self.0.push(value);
     }
 
     #[inline]


### PR DESCRIPTION
This publicizes `push_front` and `pop_front`, as well as implements `Index<usize>` for `MultiValue`.

This is simple, but it is needed to have more control over a function's arguments in place to keep error messages consistent with native Lua (for example, `bad argument #1 to '...' (string expected, got table)`), which is currently not available in `mlua` and needed to do it by myself.

While doing so, I am figuring out a Rusty way to make `mlua`'s error message more similar to those in Lua's `lauxlib`. But before it, this is enough for me to work.