### PR TITLE
`Function::bind`: simply clone the function if args are empty `MultiValue`

### DIFF
--- a/src/function.rs
+++ b/src/function.rs
@@ -208,6 +208,10 @@ impl<'lua> Function<'lua> {
         let args = args.to_lua_multi(lua)?;
         let nargs = args.len() as c_int;
 
+        if nargs == 0 {
+            return Ok(self.clone());
+        }
+
         if nargs + 1 > ffi::LUA_MAX_UPVALUES {
             return Err(Error::BindError);
         }


### PR DESCRIPTION
I encountered a Lua "assertion failed" while writing my code:
```
Assertion failed: ((o < L->top) && "invalid index"), function index2stack, file lapi.c, line 98.
zsh: abort      cargo run -- dev
```

It seems to be related to `Function::bind`, when an empty `MultiValue` causes the error, while an occupied one does not.

I failed to reproduce it with minimal code, but here's the code that throws the error: [source](https://github.com/hack3ric/abel/blob/8ef6dba1b00368b1a2e3e96942297134327632d1/rt/src/lua/spawn.rs#L20). Simply replace the line with `let f = f.bind(args)?;`.

It might be a deeper error, but this workaround works for me. It's a small optimization after all.

Edit: I believe it's [here](https://github.com/khvzak/mlua/blob/d3b48cf2f314f780dfa1d2eb91645cc3c78db4ee/src/function.rs#L201) that the problem occurs, according to my debugger.