### PR TITLE
Fix build for emscripten target

### DIFF
--- a/mlua-sys/src/lua51/lua.rs
+++ b/mlua-sys/src/lua51/lua.rs
@@ -228,11 +228,20 @@ extern "C-unwind" {
 //
 #[cfg_attr(all(windows, raw_dylib), link(name = "lua51", kind = "raw-dylib"))]
 extern "C-unwind" {
-    pub fn lua_error(L: *mut lua_State) -> !;
+    #[link_name = "lua_error"]
+    fn lua_error_(L: *mut lua_State) -> c_int;
     pub fn lua_next(L: *mut lua_State, idx: c_int) -> c_int;
     pub fn lua_concat(L: *mut lua_State, n: c_int);
     pub fn lua_getallocf(L: *mut lua_State, ud: *mut *mut c_void) -> lua_Alloc;
     pub fn lua_setallocf(L: *mut lua_State, f: lua_Alloc, ud: *mut c_void);
+}
+
+// lua_error does not return but is declared to return int, and Rust translates
+// ! to void which can cause link-time errors if the platform linker is aware
+// of return types and requires they match (for example: wasm does this).
+pub unsafe fn lua_error(L: *mut lua_State) -> ! {
+    lua_error_(L);
+    unreachable!();
 }
 
 //

--- a/mlua-sys/src/lua52/lua.rs
+++ b/mlua-sys/src/lua52/lua.rs
@@ -308,12 +308,21 @@ extern "C-unwind" {
     //
     // Miscellaneous functions
     //
-    pub fn lua_error(L: *mut lua_State) -> !;
+    #[link_name = "lua_error"]
+    fn lua_error_(L: *mut lua_State) -> c_int;
     pub fn lua_next(L: *mut lua_State, idx: c_int) -> c_int;
     pub fn lua_concat(L: *mut lua_State, n: c_int);
     pub fn lua_len(L: *mut lua_State, idx: c_int);
     pub fn lua_getallocf(L: *mut lua_State, ud: *mut *mut c_void) -> lua_Alloc;
     pub fn lua_setallocf(L: *mut lua_State, f: lua_Alloc, ud: *mut c_void);
+}
+
+// lua_error does not return but is declared to return int, and Rust translates
+// ! to void which can cause link-time errors if the platform linker is aware
+// of return types and requires they match (for example: wasm does this).
+pub unsafe fn lua_error(L: *mut lua_State) -> ! {
+    lua_error_(L);
+    unreachable!();
 }
 
 //

--- a/mlua-sys/src/lua53/lua.rs
+++ b/mlua-sys/src/lua53/lua.rs
@@ -314,13 +314,22 @@ extern "C-unwind" {
     //
     // Miscellaneous functions
     //
-    pub fn lua_error(L: *mut lua_State) -> !;
+    #[link_name = "lua_error"]
+    fn lua_error_(L: *mut lua_State) -> c_int;
     pub fn lua_next(L: *mut lua_State, idx: c_int) -> c_int;
     pub fn lua_concat(L: *mut lua_State, n: c_int);
     pub fn lua_len(L: *mut lua_State, idx: c_int);
     pub fn lua_stringtonumber(L: *mut lua_State, s: *const c_char) -> usize;
     pub fn lua_getallocf(L: *mut lua_State, ud: *mut *mut c_void) -> lua_Alloc;
     pub fn lua_setallocf(L: *mut lua_State, f: lua_Alloc, ud: *mut c_void);
+}
+
+// lua_error does not return but is declared to return int, and Rust translates
+// ! to void which can cause link-time errors if the platform linker is aware
+// of return types and requires they match (for example: wasm does this).
+pub unsafe fn lua_error(L: *mut lua_State) -> ! {
+    lua_error_(L);
+    unreachable!();
 }
 
 //

--- a/mlua-sys/src/lua54/lua.rs
+++ b/mlua-sys/src/lua54/lua.rs
@@ -149,11 +149,18 @@ extern "C-unwind" {
     pub fn lua_tointegerx(L: *mut lua_State, idx: c_int, isnum: *mut c_int) -> lua_Integer;
     pub fn lua_toboolean(L: *mut lua_State, idx: c_int) -> c_int;
     pub fn lua_tolstring(L: *mut lua_State, idx: c_int, len: *mut usize) -> *const c_char;
-    pub fn lua_rawlen(L: *mut lua_State, idx: c_int) -> usize;
+    #[link_name = "lua_rawlen"]
+    fn lua_rawlen_(L: *mut lua_State, idx: c_int) -> lua_Unsigned;
     pub fn lua_tocfunction(L: *mut lua_State, idx: c_int) -> Option<lua_CFunction>;
     pub fn lua_touserdata(L: *mut lua_State, idx: c_int) -> *mut c_void;
     pub fn lua_tothread(L: *mut lua_State, idx: c_int) -> *mut lua_State;
     pub fn lua_topointer(L: *mut lua_State, idx: c_int) -> *const c_void;
+}
+
+// lua_rawlen's return type changed from size_t to lua_Unsigned int in Lua 5.4.
+// This adapts the crate API to the new Lua ABI.
+pub unsafe fn lua_rawlen(L: *mut lua_State, idx: c_int) -> usize {
+    lua_rawlen_(L, idx) as usize
 }
 
 //

--- a/mlua-sys/src/lua54/lua.rs
+++ b/mlua-sys/src/lua54/lua.rs
@@ -343,7 +343,8 @@ extern "C-unwind" {
     //
     // Miscellaneous functions
     //
-    pub fn lua_error(L: *mut lua_State) -> !;
+    #[link_name = "lua_error"]
+    fn lua_error_(L: *mut lua_State) -> c_int;
     pub fn lua_next(L: *mut lua_State, idx: c_int) -> c_int;
     pub fn lua_concat(L: *mut lua_State, n: c_int);
     pub fn lua_len(L: *mut lua_State, idx: c_int);
@@ -353,6 +354,14 @@ extern "C-unwind" {
 
     pub fn lua_toclose(L: *mut lua_State, idx: c_int);
     pub fn lua_closeslot(L: *mut lua_State, idx: c_int);
+}
+
+// lua_error does not return but is declared to return int, and Rust translates
+// ! to void which can cause link-time errors if the platform linker is aware
+// of return types and requires they match (for example: wasm does this).
+pub unsafe fn lua_error(L: *mut lua_State) -> ! {
+    lua_error_(L);
+    unreachable!();
 }
 
 //


### PR DESCRIPTION
This fixes some ABI issues I encountered while building for wasm32-unknown-emscripten after enabling lua-src to build with https://github.com/khvzak/lua-src-rs/pull/8. The public API is unchanged despite needing to change some of the FFI declarations.

Commit b16f3895a0d14b1ef80c9c0f07b97f990f124c32 isn't a wasm-specific fix, but the issue it causes is unlikely to be noticed on other platforms unless it causes an ABI break leading to crashes.